### PR TITLE
update links

### DIFF
--- a/content/docs/components/banner/index.mdx
+++ b/content/docs/components/banner/index.mdx
@@ -25,17 +25,17 @@ You can change the variant of the banner to `default`, `minimal`, or `popup`.
 <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
   <Tab value="npx">
     ```bash
-    npx shadcn@latest add banner
+    npx shadcn@latest add https://billingsdk.vercel.app/r/banner.json
     ```
   </Tab>
   <Tab value="pnpm">
     ```bash
-    pnpm dlx shadcn@latest add banner
+    pnpm dlx shadcn@latest add https://billingsdk.vercel.app/r/banner.json
     ```
   </Tab>
   <Tab value="yarn">
     ```bash
-    npx shadcn@latest add banner
+    npx shadcn@latest add https://billingsdk.vercel.app/r/banner.json
     ```
   </Tab>
 </Tabs>

--- a/content/docs/components/cancel-subscription/cancel-subscription-card.mdx
+++ b/content/docs/components/cancel-subscription/cancel-subscription-card.mdx
@@ -21,17 +21,17 @@ description: The Cancel Subscription Card component provides a comprehensive and
 <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
   <Tab value="npx">
     ```bash
-    npx shadcn@latest add cancel-subscription-card
+    npx shadcn@latest add https://billingsdk.vercel.app/r/cancel-subscription-card.json
     ```
   </Tab>
   <Tab value="pnpm">
     ```bash
-    pnpm dlx shadcn@latest add cancel-subscription-card
+    pnpm dlx shadcn@latest add https://billingsdk.vercel.app/r/cancel-subscription-card.json
     ```
   </Tab>
   <Tab value="yarn">
     ```bash
-    npx shadcn@latest add cancel-subscription-card
+    npx shadcn@latest add https://billingsdk.vercel.app/r/cancel-subscription-card.json
     ```
   </Tab>
 </Tabs>

--- a/content/docs/components/cancel-subscription/cancel-subscription-dialog.mdx
+++ b/content/docs/components/cancel-subscription/cancel-subscription-dialog.mdx
@@ -21,17 +21,17 @@ description: The Cancel Subscription Dialog component provides a comprehensive a
 <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
   <Tab value="npx">
     ```bash
-    npx shadcn@latest add cancel-subscription-dialog
+    npx shadcn@latest add https://billingsdk.vercel.app/r/cancel-subscription-dialog.json
     ```
   </Tab>
   <Tab value="pnpm">
     ```bash
-    pnpm dlx shadcn@latest add cancel-subscription-dialog
+    pnpm dlx shadcn@latest add https://billingsdk.vercel.app/r/cancel-subscription-dialog.json
     ```
   </Tab>
   <Tab value="yarn">
     ```bash
-    npx shadcn@latest add cancel-subscription-dialog
+    npx shadcn@latest add https://billingsdk.vercel.app/r/cancel-subscription-dialog.json
     ```
   </Tab>
 </Tabs>

--- a/content/docs/components/manage-subscription/index.mdx
+++ b/content/docs/components/manage-subscription/index.mdx
@@ -21,17 +21,17 @@ description: The Manage Subscription component provides a comprehensive interfac
 <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
   <Tab value="npx">
     ```bash
-    npx shadcn@latest add subscription-management
+    npx shadcn@latest add https://billingsdk.vercel.app/r/subscription-management.json
     ```
   </Tab>
   <Tab value="pnpm">
     ```bash
-    pnpm dlx shadcn@latest add subscription-management
+    pnpm dlx shadcn@latest add https://billingsdk.vercel.app/r/subscription-management.json
     ```
   </Tab>
   <Tab value="yarn">
     ```bash
-    npx shadcn@latest add subscription-management
+    npx shadcn@latest add https://billingsdk.vercel.app/r/subscription-management.json
     ```
   </Tab>
 </Tabs>

--- a/content/docs/components/pricing-table/pricing-table-one.mdx
+++ b/content/docs/components/pricing-table/pricing-table-one.mdx
@@ -21,17 +21,17 @@ description: The Pricing Table One component provides a clean and modern design 
 <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
   <Tab value="npx">
     ```bash
-    npx shadcn@latest add pricing-table-one
+    npx shadcn@latest add https://billingsdk.vercel.app/r/pricing-table-one.json
     ```
   </Tab>
   <Tab value="pnpm">
     ```bash
-    pnpm dlx shadcn@latest add pricing-table-one
+    pnpm dlx shadcn@latest add https://billingsdk.vercel.app/r/pricing-table-one.json
     ```
   </Tab>
   <Tab value="yarn">
     ```bash
-    npx shadcn@latest add pricing-table-one
+    npx shadcn@latest add https://billingsdk.vercel.app/r/pricing-table-one.json
     ```
   </Tab>
 </Tabs>

--- a/content/docs/components/pricing-table/pricing-table-three.mdx
+++ b/content/docs/components/pricing-table/pricing-table-three.mdx
@@ -20,17 +20,17 @@ description: The Pricing Table Three component provides a third design option fo
 <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
   <Tab value="npx">
     ```bash
-    npx shadcn@latest add pricing-table-three
+    npx shadcn@latest add https://billingsdk.vercel.app/r/pricing-table-three.json
     ``` 
   </Tab>
   <Tab value="pnpm">
     ```bash
-    pnpm dlx shadcn@latest add pricing-table-three
+    pnpm dlx shadcn@latest add https://billingsdk.vercel.app/r/pricing-table-three.json
     ```
   </Tab>
   <Tab value="yarn">
     ```bash
-    npx shadcn@latest add pricing-table-three
+    npx shadcn@latest add https://billingsdk.vercel.app/r/pricing-table-three.json
     ```
   </Tab>
 </Tabs>

--- a/content/docs/components/pricing-table/pricing-table-two.mdx
+++ b/content/docs/components/pricing-table/pricing-table-two.mdx
@@ -21,17 +21,17 @@ description: The Pricing Table Two component offers an alternative design approa
 <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
   <Tab value="npx">
     ```bash
-    npx shadcn@latest add pricing-table-two
+    npx shadcn@latest add https://billingsdk.vercel.app/r/pricing-table-two.json
     ```
   </Tab>
   <Tab value="pnpm">
     ```bash
-    pnpm dlx shadcn@latest add pricing-table-two
+    pnpm dlx shadcn@latest add https://billingsdk.vercel.app/r/pricing-table-two.json
     ```
   </Tab>
   <Tab value="yarn">
     ```bash
-    npx shadcn@latest add pricing-table-two
+    npx shadcn@latest add https://billingsdk.vercel.app/r/pricing-table-two.json  
     ```
   </Tab>
 </Tabs>

--- a/content/docs/components/update-plan/update-plan-card.mdx
+++ b/content/docs/components/update-plan/update-plan-card.mdx
@@ -21,17 +21,17 @@ description: The Update Plan Card component provides a compact, card-based inter
 <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
   <Tab value="npx">
     ```bash
-    npx shadcn@latest add update-plan-card
+    npx shadcn@latest add https://billingsdk.vercel.app/r/update-plan-card.json
     ```
   </Tab>
   <Tab value="pnpm">
     ```bash
-    pnpm dlx shadcn@latest add update-plan-card
+    pnpm dlx shadcn@latest add https://billingsdk.vercel.app/r/update-plan-card.json
     ```
   </Tab>
   <Tab value="yarn">
     ```bash
-    npx shadcn@latest add update-plan-card
+    npx shadcn@latest add https://billingsdk.vercel.app/r/update-plan-card.json
     ```
   </Tab>
 </Tabs>

--- a/content/docs/components/update-plan/update-plan-dialog.mdx
+++ b/content/docs/components/update-plan/update-plan-dialog.mdx
@@ -21,17 +21,17 @@ description: The Update Plan Dialog component provides an interactive interface 
 <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
   <Tab value="npx">
     ```bash
-    npx shadcn@latest add update-plan-dialog
+    npx shadcn@latest add https://billingsdk.vercel.app/r/update-plan-dialog.json
     ```
   </Tab>
   <Tab value="pnpm">
     ```bash
-    pnpm dlx shadcn@latest add update-plan-dialog
+    pnpm dlx shadcn@latest add https://billingsdk.vercel.app/r/update-plan-dialog.json
     ```
   </Tab>
   <Tab value="yarn">
     ```bash
-    npx shadcn@latest add update-plan-dialog
+    npx shadcn@latest add https://billingsdk.vercel.app/r/update-plan-dialog.json
     ```
   </Tab>
 </Tabs>

--- a/content/docs/components/usage-meter/usage-meter-circle.mdx
+++ b/content/docs/components/usage-meter/usage-meter-circle.mdx
@@ -21,17 +21,17 @@ description: Displays usage progress in a circular meter with an animated ring, 
 <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
   <Tab value="npx">
     ```bash
-    npx shadcn@latest add usage-meter-circle
+    npx shadcn@latest add https://billingsdk.vercel.app/r/usage-meter-circle.json
     ```
   </Tab>
   <Tab value="pnpm">
     ```bash
-    pnpm dlx shadcn@latest add usage-meter-circle
+    pnpm dlx shadcn@latest add https://billingsdk.vercel.app/r/usage-meter-circle.json
     ```
   </Tab>
   <Tab value="yarn">
     ```bash
-    npx shadcn@latest add usage-meter-circle
+    npx shadcn@latest add https://billingsdk.vercel.app/r/usage-meter-circle.json
     ```
   </Tab>
 </Tabs>

--- a/content/docs/components/usage-meter/usage-meter-linear.mdx
+++ b/content/docs/components/usage-meter/usage-meter-linear.mdx
@@ -21,17 +21,17 @@ description: Displays usage progress with an animated linear bar, remaining quot
 <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
   <Tab value="npx">
     ```bash
-    npx shadcn@latest add usage-meter-linear
+    npx shadcn@latest add https://billingsdk.vercel.app/r/usage-meter-linear.json
     ```
   </Tab>
   <Tab value="pnpm">
     ```bash
-    pnpm dlx shadcn@latest add usage-meter-linear
+    pnpm dlx shadcn@latest add https://billingsdk.vercel.app/r/usage-meter-linear.json
     ```
   </Tab>
   <Tab value="yarn">
     ```bash
-    npx shadcn@latest add usage-meter-linear
+    npx shadcn@latest add https://billingsdk.vercel.app/r/usage-meter-linear.json
     ```
   </Tab>
 </Tabs>

--- a/public/r/all.json
+++ b/public/r/all.json
@@ -5,17 +5,17 @@
   "title": "All Components",
   "description": "All components in the BillingSDK",
   "registryDependencies": [
-    "http://localhost:3000/r/pricing-table-one.json",
-    "http://localhost:3000/r/pricing-table-two.json",
-    "http://localhost:3000/r/pricing-table-three.json",
-    "http://localhost:3000/r/cancel-subscription-dialog.json",
-    "http://localhost:3000/r/cancel-subscription-card.json",
-    "http://localhost:3000/r/update-plan-dialog.json",
-    "http://localhost:3000/r/update-plan-card.json",
-    "http://localhost:3000/r/subscription-management.json",
-    "http://localhost:3000/r/usage-meter-linear.json",
-    "http://localhost:3000/r/usage-meter-circle.json",
-    "http://localhost:3000/r/banner.json"
+    "https://billingsdk.vercel.app/r/pricing-table-one.json",
+    "https://billingsdk.vercel.app/r/pricing-table-two.json",
+    "https://billingsdk.vercel.app/r/pricing-table-three.json",
+    "https://billingsdk.vercel.app/r/cancel-subscription-dialog.json",
+    "https://billingsdk.vercel.app/r/cancel-subscription-card.json",
+    "https://billingsdk.vercel.app/r/update-plan-dialog.json",
+    "https://billingsdk.vercel.app/r/update-plan-card.json",
+    "https://billingsdk.vercel.app/r/subscription-management.json",
+    "https://billingsdk.vercel.app/r/usage-meter-linear.json",
+    "https://billingsdk.vercel.app/r/usage-meter-circle.json",
+    "https://billingsdk.vercel.app/r/banner.json"
   ],
   "files": []
 }

--- a/public/r/subscription-management.json
+++ b/public/r/subscription-management.json
@@ -13,8 +13,8 @@
     "badge",
     "separator",
     "utils",
-    "http://localhost:3000/r/cancel-subscription-dialog.json",
-    "http://localhost:3000/r/update-plan-dialog.json"
+    "https://billingsdk.vercel.app/r/cancel-subscription-dialog.json",
+    "https://billingsdk.vercel.app/r/update-plan-dialog.json"
   ],
   "files": [
     {

--- a/registry.json
+++ b/registry.json
@@ -23,17 +23,17 @@
             "description": "All components in the BillingSDK",
             "files": [],
             "registryDependencies": [
-                "http://localhost:3000/r/pricing-table-one.json",
-                "http://localhost:3000/r/pricing-table-two.json",
-                "http://localhost:3000/r/pricing-table-three.json",
-                "http://localhost:3000/r/cancel-subscription-dialog.json",
-                "http://localhost:3000/r/cancel-subscription-card.json",
-                "http://localhost:3000/r/update-plan-dialog.json",
-                "http://localhost:3000/r/update-plan-card.json",
-                "http://localhost:3000/r/subscription-management.json",
-                "http://localhost:3000/r/usage-meter-linear.json",
-                "http://localhost:3000/r/usage-meter-circle.json",
-                "http://localhost:3000/r/banner.json"
+                "https://billingsdk.vercel.app/r/pricing-table-one.json",
+                "https://billingsdk.vercel.app/r/pricing-table-two.json",
+                "https://billingsdk.vercel.app/r/pricing-table-three.json",
+                "https://billingsdk.vercel.app/r/cancel-subscription-dialog.json",
+                "https://billingsdk.vercel.app/r/cancel-subscription-card.json",
+                "https://billingsdk.vercel.app/r/update-plan-dialog.json",
+                "https://billingsdk.vercel.app/r/update-plan-card.json",
+                "https://billingsdk.vercel.app/r/subscription-management.json",
+                "https://billingsdk.vercel.app/r/usage-meter-linear.json",
+                "https://billingsdk.vercel.app/r/usage-meter-circle.json",
+                "https://billingsdk.vercel.app/r/banner.json"
             ]
         },
         {
@@ -321,8 +321,8 @@
                 "badge",
                 "separator",
                 "utils",
-                "http://localhost:3000/r/cancel-subscription-dialog.json",
-                "http://localhost:3000/r/update-plan-dialog.json"
+                "https://billingsdk.vercel.app/r/cancel-subscription-dialog.json",
+                "https://billingsdk.vercel.app/r/update-plan-dialog.json"
             ]
         },
         {


### PR DESCRIPTION
This pull request updates all component installation instructions and registry dependencies to use the production CDN URLs (`https://billingsdk.vercel.app`) instead of local development URLs (`http://localhost:3000`). This standardizes the way components are fetched and ensures that users and the registry reference the correct, publicly available resources.

**Documentation updates:**

* Updated installation commands in all component documentation files to use the production CDN URLs for fetching component JSON files, replacing the previous package names or localhost URLs. [[1]](diffhunk://#diff-4c9b1a3744507334823186eeb390a470519a1f3ebc0e099a01bcccfd2ebb9efcL28-R38) [[2]](diffhunk://#diff-e3f8f8fcb1c7e15bb73ee1c75260ff85ded5a8b8589b9070fd571e33a8d92298L24-R34) [[3]](diffhunk://#diff-8c571afb6ede77f4c75ab9567bfe8385aa503ec104e36f702151004b9e38c684L24-R34) [[4]](diffhunk://#diff-8b6ce8190eae0634c796b8dc470c37a15003434c58caa2792b2d90b366bbe476L24-R34) [[5]](diffhunk://#diff-725c909484c997d8c40412794d28e903dad9502a15e6bcbfab82aee0611a652cL24-R34) [[6]](diffhunk://#diff-280317d18695c500c2017594b46fb51a3d92a10ff9807024f6c7794270b9db90L23-R33) [[7]](diffhunk://#diff-47c33f772f242813c6bab6eabc92e2f1c488819160b0a60ad78e61894b0ec110L24-R34) [[8]](diffhunk://#diff-1766f52ab69f4beacfdd17dc92111d8b5e09a849d764b328c66dbf5969a70dd1L24-R34) [[9]](diffhunk://#diff-2946a4f59cf7f7e2ea31c9c354c1d28dbf8c2390a11e58e60d426bb60beee64aL24-R34) [[10]](diffhunk://#diff-ececf6d9e1199b1bc80b3bbd9444bdde10c2c091255f475bf3f80e4d1fb79a3eL24-R34) [[11]](diffhunk://#diff-8a200f4f98d19f43311e4b0901ca44337b9194e6a1aa2a7e303a6f67258f8badL24-R34)

**Registry and dependency updates:**

* Changed all registry dependencies in `public/r/all.json`, `public/r/subscription-management.json`, and `registry.json` from localhost URLs to the production CDN URLs, ensuring that all component references are consistent and point to the correct external resources. [[1]](diffhunk://#diff-01000a14a078625008e6a285469a58749c7f87a4630d15bb2edb12e34cdcd299L8-R18) [[2]](diffhunk://#diff-7fa8db26709eceb525bbc0cdbf8205b3808f549f246cbdd0769b95b1f14324adL16-R17) [[3]](diffhunk://#diff-c1ccab6b761f7c3ef53302c329215f605bb24c73aa16fb75bc4da712926e972bL26-R36) [[4]](diffhunk://#diff-c1ccab6b761f7c3ef53302c329215f605bb24c73aa16fb75bc4da712926e972bL324-R325)