### PR TITLE
update registry and docs links to use the new billing SDK domain

### DIFF
--- a/content/docs/components/banner/index.mdx
+++ b/content/docs/components/banner/index.mdx
@@ -25,17 +25,17 @@ You can change the variant of the banner to `default`, `minimal`, or `popup`.
 <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
   <Tab value="npx">
     ```bash
-    npx shadcn@latest add https://billingsdk.vercel.app/r/banner.json
+    npx shadcn@latest add https://billingsdk.com/r/banner.json
     ```
   </Tab>
   <Tab value="pnpm">
     ```bash
-    pnpm dlx shadcn@latest add https://billingsdk.vercel.app/r/banner.json
+    pnpm dlx shadcn@latest add https://billingsdk.com/r/banner.json
     ```
   </Tab>
   <Tab value="yarn">
     ```bash
-    npx shadcn@latest add https://billingsdk.vercel.app/r/banner.json
+    npx shadcn@latest add https://billingsdk.com/r/banner.json
     ```
   </Tab>
 </Tabs>

--- a/content/docs/components/cancel-subscription/cancel-subscription-card.mdx
+++ b/content/docs/components/cancel-subscription/cancel-subscription-card.mdx
@@ -21,17 +21,17 @@ description: The Cancel Subscription Card component provides a comprehensive and
 <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
   <Tab value="npx">
     ```bash
-    npx shadcn@latest add https://billingsdk.vercel.app/r/cancel-subscription-card.json
+    npx shadcn@latest add https://billingsdk.com/r/cancel-subscription-card.json
     ```
   </Tab>
   <Tab value="pnpm">
     ```bash
-    pnpm dlx shadcn@latest add https://billingsdk.vercel.app/r/cancel-subscription-card.json
+    pnpm dlx shadcn@latest add https://billingsdk.com/r/cancel-subscription-card.json
     ```
   </Tab>
   <Tab value="yarn">
     ```bash
-    npx shadcn@latest add https://billingsdk.vercel.app/r/cancel-subscription-card.json
+    npx shadcn@latest add https://billingsdk.com/r/cancel-subscription-card.json
     ```
   </Tab>
 </Tabs>

--- a/content/docs/components/cancel-subscription/cancel-subscription-dialog.mdx
+++ b/content/docs/components/cancel-subscription/cancel-subscription-dialog.mdx
@@ -21,17 +21,17 @@ description: The Cancel Subscription Dialog component provides a comprehensive a
 <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
   <Tab value="npx">
     ```bash
-    npx shadcn@latest add https://billingsdk.vercel.app/r/cancel-subscription-dialog.json
+    npx shadcn@latest add https://billingsdk.com/r/cancel-subscription-dialog.json
     ```
   </Tab>
   <Tab value="pnpm">
     ```bash
-    pnpm dlx shadcn@latest add https://billingsdk.vercel.app/r/cancel-subscription-dialog.json
+    pnpm dlx shadcn@latest add https://billingsdk.com/r/cancel-subscription-dialog.json
     ```
   </Tab>
   <Tab value="yarn">
     ```bash
-    npx shadcn@latest add https://billingsdk.vercel.app/r/cancel-subscription-dialog.json
+    npx shadcn@latest add https://billingsdk.com/r/cancel-subscription-dialog.json
     ```
   </Tab>
 </Tabs>

--- a/content/docs/components/manage-subscription/index.mdx
+++ b/content/docs/components/manage-subscription/index.mdx
@@ -21,17 +21,17 @@ description: The Manage Subscription component provides a comprehensive interfac
 <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
   <Tab value="npx">
     ```bash
-    npx shadcn@latest add https://billingsdk.vercel.app/r/subscription-management.json
+    npx shadcn@latest add https://billingsdk.com/r/subscription-management.json
     ```
   </Tab>
   <Tab value="pnpm">
     ```bash
-    pnpm dlx shadcn@latest add https://billingsdk.vercel.app/r/subscription-management.json
+    pnpm dlx shadcn@latest add https://billingsdk.com/r/subscription-management.json
     ```
   </Tab>
   <Tab value="yarn">
     ```bash
-    npx shadcn@latest add https://billingsdk.vercel.app/r/subscription-management.json
+    npx shadcn@latest add https://billingsdk.com/r/subscription-management.json
     ```
   </Tab>
 </Tabs>

--- a/content/docs/components/pricing-table/pricing-table-one.mdx
+++ b/content/docs/components/pricing-table/pricing-table-one.mdx
@@ -37,17 +37,17 @@ description: The Pricing Table One component provides a clean and modern design 
 <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
   <Tab value="npx">
     ```bash
-    npx shadcn@latest add https://billingsdk.vercel.app/r/pricing-table-one.json
+    npx shadcn@latest add https://billingsdk.com/r/pricing-table-one.json
     ```
   </Tab>
   <Tab value="pnpm">
     ```bash
-    pnpm dlx shadcn@latest add https://billingsdk.vercel.app/r/pricing-table-one.json
+    pnpm dlx shadcn@latest add https://billingsdk.com/r/pricing-table-one.json
     ```
   </Tab>
   <Tab value="yarn">
     ```bash
-    npx shadcn@latest add https://billingsdk.vercel.app/r/pricing-table-one.json
+    npx shadcn@latest add https://billingsdk.com/r/pricing-table-one.json
     ```
   </Tab>
 </Tabs>

--- a/content/docs/components/pricing-table/pricing-table-three.mdx
+++ b/content/docs/components/pricing-table/pricing-table-three.mdx
@@ -20,17 +20,17 @@ description: The Pricing Table Three component provides a third design option fo
 <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
   <Tab value="npx">
     ```bash
-    npx shadcn@latest add https://billingsdk.vercel.app/r/pricing-table-three.json
+    npx shadcn@latest add https://billingsdk.com/r/pricing-table-three.json
     ``` 
   </Tab>
   <Tab value="pnpm">
     ```bash
-    pnpm dlx shadcn@latest add https://billingsdk.vercel.app/r/pricing-table-three.json
+    pnpm dlx shadcn@latest add https://billingsdk.com/r/pricing-table-three.json
     ```
   </Tab>
   <Tab value="yarn">
     ```bash
-    npx shadcn@latest add https://billingsdk.vercel.app/r/pricing-table-three.json
+    npx shadcn@latest add https://billingsdk.com/r/pricing-table-three.json
     ```
   </Tab>
 </Tabs>

--- a/content/docs/components/pricing-table/pricing-table-two.mdx
+++ b/content/docs/components/pricing-table/pricing-table-two.mdx
@@ -39,17 +39,17 @@ description: The Pricing Table Two component offers an alternative design approa
 <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
   <Tab value="npx">
     ```bash
-    npx shadcn@latest add https://billingsdk.vercel.app/r/pricing-table-two.json
+    npx shadcn@latest add https://billingsdk.com/r/pricing-table-two.json
     ```
   </Tab>
   <Tab value="pnpm">
     ```bash
-    pnpm dlx shadcn@latest add https://billingsdk.vercel.app/r/pricing-table-two.json
+    pnpm dlx shadcn@latest add https://billingsdk.com/r/pricing-table-two.json
     ```
   </Tab>
   <Tab value="yarn">
     ```bash
-    npx shadcn@latest add https://billingsdk.vercel.app/r/pricing-table-two.json  
+    npx shadcn@latest add https://billingsdk.com/r/pricing-table-two.json  
     ```
   </Tab>
 </Tabs>

--- a/content/docs/components/update-plan/update-plan-card.mdx
+++ b/content/docs/components/update-plan/update-plan-card.mdx
@@ -21,17 +21,17 @@ description: The Update Plan Card component provides a compact, card-based inter
 <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
   <Tab value="npx">
     ```bash
-    npx shadcn@latest add https://billingsdk.vercel.app/r/update-plan-card.json
+    npx shadcn@latest add https://billingsdk.com/r/update-plan-card.json
     ```
   </Tab>
   <Tab value="pnpm">
     ```bash
-    pnpm dlx shadcn@latest add https://billingsdk.vercel.app/r/update-plan-card.json
+    pnpm dlx shadcn@latest add https://billingsdk.com/r/update-plan-card.json
     ```
   </Tab>
   <Tab value="yarn">
     ```bash
-    npx shadcn@latest add https://billingsdk.vercel.app/r/update-plan-card.json
+    npx shadcn@latest add https://billingsdk.com/r/update-plan-card.json
     ```
   </Tab>
 </Tabs>

--- a/content/docs/components/update-plan/update-plan-dialog.mdx
+++ b/content/docs/components/update-plan/update-plan-dialog.mdx
@@ -21,17 +21,17 @@ description: The Update Plan Dialog component provides an interactive interface 
 <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
   <Tab value="npx">
     ```bash
-    npx shadcn@latest add https://billingsdk.vercel.app/r/update-plan-dialog.json
+    npx shadcn@latest add https://billingsdk.com/r/update-plan-dialog.json
     ```
   </Tab>
   <Tab value="pnpm">
     ```bash
-    pnpm dlx shadcn@latest add https://billingsdk.vercel.app/r/update-plan-dialog.json
+    pnpm dlx shadcn@latest add https://billingsdk.com/r/update-plan-dialog.json
     ```
   </Tab>
   <Tab value="yarn">
     ```bash
-    npx shadcn@latest add https://billingsdk.vercel.app/r/update-plan-dialog.json
+    npx shadcn@latest add https://billingsdk.com/r/update-plan-dialog.json
     ```
   </Tab>
 </Tabs>

--- a/content/docs/components/usage-meter/usage-meter-circle.mdx
+++ b/content/docs/components/usage-meter/usage-meter-circle.mdx
@@ -21,17 +21,17 @@ description: Displays usage progress in a circular meter with an animated ring, 
 <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
   <Tab value="npx">
     ```bash
-    npx shadcn@latest add https://billingsdk.vercel.app/r/usage-meter-circle.json
+    npx shadcn@latest add https://billingsdk.com/r/usage-meter-circle.json
     ```
   </Tab>
   <Tab value="pnpm">
     ```bash
-    pnpm dlx shadcn@latest add https://billingsdk.vercel.app/r/usage-meter-circle.json
+    pnpm dlx shadcn@latest add https://billingsdk.com/r/usage-meter-circle.json
     ```
   </Tab>
   <Tab value="yarn">
     ```bash
-    npx shadcn@latest add https://billingsdk.vercel.app/r/usage-meter-circle.json
+    npx shadcn@latest add https://billingsdk.com/r/usage-meter-circle.json
     ```
   </Tab>
 </Tabs>

--- a/content/docs/components/usage-meter/usage-meter-linear.mdx
+++ b/content/docs/components/usage-meter/usage-meter-linear.mdx
@@ -21,17 +21,17 @@ description: Displays usage progress with an animated linear bar, remaining quot
 <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
   <Tab value="npx">
     ```bash
-    npx shadcn@latest add https://billingsdk.vercel.app/r/usage-meter-linear.json
+    npx shadcn@latest add https://billingsdk.com/r/usage-meter-linear.json
     ```
   </Tab>
   <Tab value="pnpm">
     ```bash
-    pnpm dlx shadcn@latest add https://billingsdk.vercel.app/r/usage-meter-linear.json
+    pnpm dlx shadcn@latest add https://billingsdk.com/r/usage-meter-linear.json
     ```
   </Tab>
   <Tab value="yarn">
     ```bash
-    npx shadcn@latest add https://billingsdk.vercel.app/r/usage-meter-linear.json
+    npx shadcn@latest add https://billingsdk.com/r/usage-meter-linear.json
     ```
   </Tab>
 </Tabs>

--- a/content/docs/quick-start.mdx
+++ b/content/docs/quick-start.mdx
@@ -14,25 +14,25 @@ A minimum version of Node.js 18 required. Install any component with a single co
 <Tabs items={['npm', 'pnpm', 'yarn', 'bun']}>
   <Tab value="npm">
     ```bash
-    npx shadcn@latest add https://billingsdk.vercel.app/r/<component-name>.json
+    npx shadcn@latest add https://billingsdk.com/r/<component-name>.json
     ```
   </Tab>
 
   <Tab value="pnpm">
     ```bash
-    pnpm dlx shadcn@latest add https://billingsdk.vercel.app/r/<component-name>.json
+    pnpm dlx shadcn@latest add https://billingsdk.com/r/<component-name>.json
     ```
   </Tab>
 
   <Tab value="yarn">
     ```bash
-    npx shadcn@latest add https://billingsdk.vercel.app/r/<component-name>.json
+    npx shadcn@latest add https://billingsdk.com/r/<component-name>.json
     ```
   </Tab>
 
   <Tab value="bun">
     ```bash
-    npx shadcn@latest add https://billingsdk.vercel.app/r/<component-name>.json
+    npx shadcn@latest add https://billingsdk.com/r/<component-name>.json
     ```
   </Tab>
 </Tabs>
@@ -95,7 +95,7 @@ Use the component in your application and see it in action.
 ### Install a Pricing Table
 
 ```bash
-npx shadcn@latest add https://billingsdk.vercel.app/r/pricing-table-one.json
+npx shadcn@latest add https://billingsdk.com/r/pricing-table-one.json
 ```
 
 ### Use in Your App

--- a/public/r/all.json
+++ b/public/r/all.json
@@ -5,17 +5,17 @@
   "title": "All Components",
   "description": "All components in the BillingSDK",
   "registryDependencies": [
-    "https://billingsdk.vercel.app/r/pricing-table-one.json",
-    "https://billingsdk.vercel.app/r/pricing-table-two.json",
-    "https://billingsdk.vercel.app/r/pricing-table-three.json",
-    "https://billingsdk.vercel.app/r/cancel-subscription-dialog.json",
-    "https://billingsdk.vercel.app/r/cancel-subscription-card.json",
-    "https://billingsdk.vercel.app/r/update-plan-dialog.json",
-    "https://billingsdk.vercel.app/r/update-plan-card.json",
-    "https://billingsdk.vercel.app/r/subscription-management.json",
-    "https://billingsdk.vercel.app/r/usage-meter-linear.json",
-    "https://billingsdk.vercel.app/r/usage-meter-circle.json",
-    "https://billingsdk.vercel.app/r/banner.json"
+    "https://billingsdk.com/r/pricing-table-one.json",
+    "https://billingsdk.com/r/pricing-table-two.json",
+    "https://billingsdk.com/r/pricing-table-three.json",
+    "https://billingsdk.com/r/cancel-subscription-dialog.json",
+    "https://billingsdk.com/r/cancel-subscription-card.json",
+    "https://billingsdk.com/r/update-plan-dialog.json",
+    "https://billingsdk.com/r/update-plan-card.json",
+    "https://billingsdk.com/r/subscription-management.json",
+    "https://billingsdk.com/r/usage-meter-linear.json",
+    "https://billingsdk.com/r/usage-meter-circle.json",
+    "https://billingsdk.com/r/banner.json"
   ],
   "files": []
 }

--- a/public/r/subscription-management.json
+++ b/public/r/subscription-management.json
@@ -13,8 +13,8 @@
     "badge",
     "separator",
     "utils",
-    "https://billingsdk.vercel.app/r/cancel-subscription-dialog.json",
-    "https://billingsdk.vercel.app/r/update-plan-dialog.json"
+    "https://billingsdk.com/r/cancel-subscription-dialog.json",
+    "https://billingsdk.com/r/update-plan-dialog.json"
   ],
   "files": [
     {

--- a/registry.json
+++ b/registry.json
@@ -23,17 +23,17 @@
             "description": "All components in the BillingSDK",
             "files": [],
             "registryDependencies": [
-                "https://billingsdk.vercel.app/r/pricing-table-one.json",
-                "https://billingsdk.vercel.app/r/pricing-table-two.json",
-                "https://billingsdk.vercel.app/r/pricing-table-three.json",
-                "https://billingsdk.vercel.app/r/cancel-subscription-dialog.json",
-                "https://billingsdk.vercel.app/r/cancel-subscription-card.json",
-                "https://billingsdk.vercel.app/r/update-plan-dialog.json",
-                "https://billingsdk.vercel.app/r/update-plan-card.json",
-                "https://billingsdk.vercel.app/r/subscription-management.json",
-                "https://billingsdk.vercel.app/r/usage-meter-linear.json",
-                "https://billingsdk.vercel.app/r/usage-meter-circle.json",
-                "https://billingsdk.vercel.app/r/banner.json"
+                "https://billingsdk.com/r/pricing-table-one.json",
+                "https://billingsdk.com/r/pricing-table-two.json",
+                "https://billingsdk.com/r/pricing-table-three.json",
+                "https://billingsdk.com/r/cancel-subscription-dialog.json",
+                "https://billingsdk.com/r/cancel-subscription-card.json",
+                "https://billingsdk.com/r/update-plan-dialog.json",
+                "https://billingsdk.com/r/update-plan-card.json",
+                "https://billingsdk.com/r/subscription-management.json",
+                "https://billingsdk.com/r/usage-meter-linear.json",
+                "https://billingsdk.com/r/usage-meter-circle.json",
+                "https://billingsdk.com/r/banner.json"
             ]
         },
         {
@@ -324,8 +324,8 @@
                 "badge",
                 "separator",
                 "utils",
-                "https://billingsdk.vercel.app/r/cancel-subscription-dialog.json",
-                "https://billingsdk.vercel.app/r/update-plan-dialog.json"
+                "https://billingsdk.com/r/cancel-subscription-dialog.json",
+                "https://billingsdk.com/r/update-plan-dialog.json"
             ]
         },
         {

--- a/src/components/preview/preview-components.tsx
+++ b/src/components/preview/preview-components.tsx
@@ -17,7 +17,7 @@ interface PreviewComponentsProps {
 export function PreviewComponents({ className, children, registryName }: PreviewComponentsProps) {
   const { currentTheme, setTheme, themes, previewDarkMode, setPreviewDarkMode } = useTheme();
   const themeStyles = getThemeStyles(currentTheme, previewDarkMode);
-  const registryUrl = `https://billingsdk.vercel.app/r/${registryName}.json`;
+  const registryUrl = `https://billingsdk.com/r/${registryName}.json`;
 
   return (
     <Card 


### PR DESCRIPTION
This pull request updates all references to the component registry URLs from the old `billingsdk.vercel.app` domain to the new `billingsdk.com` domain. This ensures that all documentation, configuration files, and the codebase consistently use the new canonical registry endpoint for component installation and dependencies.

**Registry URL migration:**

* Updated all installation command examples in documentation files (such as `quick-start.mdx`, and all component docs) to use `https://billingsdk.com/r/...` instead of the old `vercel.app` URLs. [[1]](diffhunk://#diff-a041618c46e80b52055707de0c0f2ceb020226f39ced489f3205e7ea320aaed4L17-R35) [[2]](diffhunk://#diff-a041618c46e80b52055707de0c0f2ceb020226f39ced489f3205e7ea320aaed4L98-R98) [[3]](diffhunk://#diff-4c9b1a3744507334823186eeb390a470519a1f3ebc0e099a01bcccfd2ebb9efcL28-R38) [[4]](diffhunk://#diff-e3f8f8fcb1c7e15bb73ee1c75260ff85ded5a8b8589b9070fd571e33a8d92298L24-R34) [[5]](diffhunk://#diff-8c571afb6ede77f4c75ab9567bfe8385aa503ec104e36f702151004b9e38c684L24-R34) [[6]](diffhunk://#diff-8b6ce8190eae0634c796b8dc470c37a15003434c58caa2792b2d90b366bbe476L24-R34) [[7]](diffhunk://#diff-725c909484c997d8c40412794d28e903dad9502a15e6bcbfab82aee0611a652cL40-R50) [[8]](diffhunk://#diff-280317d18695c500c2017594b46fb51a3d92a10ff9807024f6c7794270b9db90L23-R33) [[9]](diffhunk://#diff-47c33f772f242813c6bab6eabc92e2f1c488819160b0a60ad78e61894b0ec110L42-R52) [[10]](diffhunk://#diff-1766f52ab69f4beacfdd17dc92111d8b5e09a849d764b328c66dbf5969a70dd1L24-R34) [[11]](diffhunk://#diff-2946a4f59cf7f7e2ea31c9c354c1d28dbf8c2390a11e58e60d426bb60beee64aL24-R34) [[12]](diffhunk://#diff-ececf6d9e1199b1bc80b3bbd9444bdde10c2c091255f475bf3f80e4d1fb79a3eL24-R34) [[13]](diffhunk://#diff-8a200f4f98d19f43311e4b0901ca44337b9194e6a1aa2a7e303a6f67258f8badL24-R34)

* Changed all registry dependency URLs in `public/r/all.json`, `public/r/subscription-management.json`, and `registry.json` to point to `billingsdk.com`. [[1]](diffhunk://#diff-01000a14a078625008e6a285469a58749c7f87a4630d15bb2edb12e34cdcd299L8-R18) [[2]](diffhunk://#diff-7fa8db26709eceb525bbc0cdbf8205b3808f549f246cbdd0769b95b1f14324adL16-R17) [[3]](diffhunk://#diff-c1ccab6b761f7c3ef53302c329215f605bb24c73aa16fb75bc4da712926e972bL26-R36) [[4]](diffhunk://#diff-c1ccab6b761f7c3ef53302c329215f605bb24c73aa16fb75bc4da712926e972bL327-R328)

**Code update:**

* Updated the `PreviewComponents` component to construct registry URLs using `billingsdk.com` for fetching component previews.