### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/dodopayments/billingsdk/security/code-scanning/1](https://github.com/dodopayments/billingsdk/security/code-scanning/1)

The fix is to restrict the permissions that the GITHUB_TOKEN has by adding a `permissions` block in the workflow. The minimal and safest starting permissions for a workflow that simply checks out code and runs local tasks (install, lint, build, etc.) is `contents: read`. This block should be added at the root (top) level of the workflow YAML file, before the `jobs:` key, so its scope covers all jobs in the workflow uniformly. Only this change is needed in the `.github/workflows/ci.yml` file—no other definitions, imports, or methods are relevant.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
