### PR TITLE
Added Open in AI options (lovable & bolt).

### DIFF
--- a/src/components/preview/preview-components.tsx
+++ b/src/components/preview/preview-components.tsx
@@ -19,6 +19,49 @@ export function PreviewComponents({ className, children, registryName }: Preview
   const themeStyles = getThemeStyles(currentTheme, previewDarkMode);
   const registryUrl = `https://billingsdk.com/r/${registryName}.json`;
 
+  // Open-in helpers
+  const openInV0 = () => {
+    window.open(`https://v0.dev/chat/api/open?url=${registryUrl}`, '_blank')
+  }
+
+  const openInLovable = () => {
+    const prompt = encodeURIComponent(
+      `Import this component from ${registryUrl} and open the code for editing. IMPORTANT: preserve the component exactly as-is. Do NOT change colors, CSS variables, Tailwind classes, spacing, fonts, or any visual styles. Do NOT regenerate or restyle the UI. Create files from the registry JSON verbatim and show the code tree.`
+    )
+    const lovableUrl = `https://lovable.dev/?prompt=${prompt}&autosubmit=true`
+    window.open(lovableUrl, '_blank')
+  }
+
+  const openInBolt = async () => {
+    try {
+      const res = await fetch(registryUrl)
+      const text = await res.text()
+      const MAX_EMBED = 1400
+      if (text.length <= MAX_EMBED) {
+        const prompt = encodeURIComponent(
+          `Here is a shadcn registry JSON for a component. Create a new project with these files and open the code for editing. IMPORTANT: import files verbatim and preserve ALL styles/colors/classes/fonts as-is. Do NOT restyle or regenerate the UI. JSON contents below as inline text.\n\n${text}`,
+        )
+        const boltUrl = `https://bolt.new/?prompt=${prompt}&autosubmit=true`
+        window.open(boltUrl, '_blank')
+      } else {
+        try {
+          await navigator.clipboard.writeText(text)
+        } catch {}
+        const prompt = encodeURIComponent(
+          `I have copied a shadcn registry JSON for a component to the clipboard. Create the project by pasting the JSON I will provide and generate the files, then open the code for editing. IMPORTANT: import files verbatim and preserve ALL styles/colors/classes/fonts as-is. Do NOT restyle or regenerate the UI. If clipboard is not available, ask me to paste the JSON.`,
+        )
+        const boltUrl = `https://bolt.new/?prompt=${prompt}&autosubmit=true`
+        window.open(boltUrl, '_blank')
+      }
+    } catch {
+      const promptFallback = encodeURIComponent(
+        `Import this component from ${registryUrl} and open the code for editing. IMPORTANT: preserve the component exactly as-is (no color/style/layout changes). If you cannot fetch external URLs, ask me to paste the JSON from that link.`,
+      )
+      const boltUrl = `https://bolt.new/?prompt=${promptFallback}&autosubmit=true`
+      window.open(boltUrl, '_blank')
+    }
+  }
+
   return (
     <Card 
       className={cn("not-prose bg-background", className)} 
@@ -28,28 +71,121 @@ export function PreviewComponents({ className, children, registryName }: Preview
         <div className="flex gap-2 justify-end">
           <div className="flex gap-2">
             {registryName && (
-            <Button
-              onClick={() => window.open(`https://v0.dev/chat/api/open?url=${registryUrl}`, '_blank')}
-              size={"sm"}
-              aria-label="Open in V0"
-            >
-              <span className="hidden md:block">Open in</span>
-              <svg 
-                viewBox="0 0 40 20" 
-                fill="none" 
-                xmlns="http://www.w3.org/2000/svg" 
-                className="h-4 w-4 text-current"
-              >
-                <path 
-                  d="M23.3919 0H32.9188C36.7819 0 39.9136 3.13165 39.9136 6.99475V16.0805H36.0006V6.99475C36.0006 6.90167 35.9969 6.80925 35.9898 6.71766L26.4628 16.079C26.4949 16.08 26.5272 16.0805 26.5595 16.0805H36.0006V19.7762H26.5595C22.6964 19.7762 19.4788 16.6139 19.4788 12.7508V3.68923H23.3919V12.7508C23.3919 12.9253 23.4054 13.0977 23.4316 13.2668L33.1682 3.6995C33.0861 3.6927 33.003 3.68923 32.9188 3.68923H23.3919V0Z" 
-                  fill="currentColor"
-                />
-                <path 
-                  d="M13.7688 19.0956L0 3.68759H5.53933L13.6231 12.7337V3.68759H17.7535V17.5746C17.7535 19.6705 15.1654 20.6584 13.7688 19.0956Z" 
-                  fill="currentColor"
-                />
-              </svg>
-            </Button>
+            <div className="flex items-center">
+              <Button variant="outline" size={"sm"} aria-label="Open in V0" onClick={openInV0} className="rounded-r-none border-r-0" style={{ 
+                backgroundColor: previewDarkMode ? '#ffffff' : '#000000',
+                color: previewDarkMode ? '#000000' : '#ffffff',
+                borderColor: previewDarkMode ? '#ffffff' : '#000000'
+              }}>
+                <span className="hidden md:block">Open in</span>
+                <svg
+                  viewBox="0 0 40 20"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="h-4 w-4 text-current"
+                >
+                  <path
+                    d="M23.3919 0H32.9188C36.7819 0 39.9136 3.13165 39.9136 6.99475V16.0805H36.0006V6.99475C36.0006 6.90167 35.9969 6.80925 35.9898 6.71766L26.4628 16.079C26.4949 16.08 26.5272 16.0805 26.5595 16.0805H36.0006V19.7762H26.5595C22.6964 19.7762 19.4788 16.6139 19.4788 12.7508V3.68923H23.3919V12.7508C23.3919 12.9253 23.4054 13.0977 23.4316 13.2668L33.1682 3.6995C33.0861 3.6927 33.003 3.68923 32.9188 3.68923H23.3919V0Z"
+                    fill="currentColor"
+                  />
+                  <path
+                    d="M13.7688 19.0956L0 3.68759H5.53933L13.6231 12.7337V3.68759H17.7535V17.5746C17.7535 19.6705 15.1654 20.6584 13.7688 19.0956Z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </Button>
+              <DropdownMenu.Root>
+                <DropdownMenu.Trigger asChild>
+                  <Button variant="outline" size={"sm"} className="rounded-l-none border-l-0 px-2" style={{ 
+                    backgroundColor: previewDarkMode ? '#ffffff' : '#000000',
+                    color: previewDarkMode ? '#000000' : '#ffffff',
+                    borderColor: previewDarkMode ? '#ffffff' : '#000000'
+                  }}>
+                    <svg
+                      className="h-4 w-4 text-current"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M19 9l-7 7-7-7"
+                      />
+                    </svg>
+                  </Button>
+                </DropdownMenu.Trigger>
+              <DropdownMenu.Portal>
+                <DropdownMenu.Content
+                  className="overflow-hidden rounded-md border shadow-md z-50"
+                  sideOffset={4}
+                  style={{
+                    backgroundColor: previewDarkMode ? '#ffffff' : '#000000',
+                    color: previewDarkMode ? '#000000' : '#ffffff',
+                    borderColor: previewDarkMode ? '#ffffff' : '#000000',
+                    width: 'fit-content',
+                    minWidth: '100%'
+                  }}
+                >
+                  <DropdownMenu.Item
+                    className={cn(
+                      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors",
+                      "hover:bg-accent hover:text-accent-foreground"
+                    )}
+                    style={{ 
+                      color: previewDarkMode ? '#000000' : '#ffffff',
+                      backgroundColor: previewDarkMode ? '#ffffff' : '#000000'
+                    }}
+                    onClick={openInLovable}
+                  >
+                    <svg
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                      className="h-4 w-4 mr-2"
+                      style={{ 
+                        color: previewDarkMode ? '#000000' : '#ffffff',
+                        transform: 'rotate(45deg)'
+                      }}
+                    >
+                      <path
+                        d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                    Lovable
+                  </DropdownMenu.Item>
+                  <DropdownMenu.Item
+                    className={cn(
+                      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors",
+                      "hover:bg-accent hover:text-accent-foreground"
+                    )}
+                    style={{ 
+                      color: previewDarkMode ? '#000000' : '#ffffff',
+                      backgroundColor: previewDarkMode ? '#ffffff' : '#000000'
+                    }}
+                    onClick={openInBolt}
+                  >
+                    <svg
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                      className="h-4 w-4 mr-2"
+                      style={{ color: previewDarkMode ? '#000000' : '#ffffff' }}
+                    >
+                      <path
+                        d="M13 2L3 14h9l-1 8 12-12h-9l1-8z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                    Bolt
+                  </DropdownMenu.Item>
+                </DropdownMenu.Content>
+              </DropdownMenu.Portal>
+            </DropdownMenu.Root>
+            </div>
             )}
             <Button 
               variant="ghost" 
@@ -73,16 +209,27 @@ export function PreviewComponents({ className, children, registryName }: Preview
               </DropdownMenu.Trigger>
               <DropdownMenu.Portal>
                 <DropdownMenu.Content 
-                  className="min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md z-50"
+                  className="overflow-hidden rounded-md border shadow-md z-50"
                   sideOffset={4}
+                  style={{
+                    backgroundColor: previewDarkMode ? '#ffffff' : '#000000',
+                    color: previewDarkMode ? '#000000' : '#ffffff',
+                    borderColor: previewDarkMode ? '#ffffff' : '#000000',
+                    width: 'fit-content',
+                    minWidth: '100%'
+                  }}
                 >
                   {themes.map((theme) => (
                     <DropdownMenu.Item
                       key={theme.name}
                       className={cn(
-                        "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+                        "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
                         "hover:bg-accent hover:text-accent-foreground"
                       )}
+                      style={{ 
+                        color: previewDarkMode ? '#000000' : '#ffffff',
+                        backgroundColor: previewDarkMode ? '#ffffff' : '#000000'
+                      }}
                       onClick={() => setTheme(theme)}
                     >
                       <div className="flex items-center gap-2">
@@ -94,7 +241,7 @@ export function PreviewComponents({ className, children, registryName }: Preview
                         />
                         <span>{theme.label}</span>
                         {currentTheme.name === theme.name && (
-                          <Check className="ml-auto h-4 w-4" />
+                          <Check className="ml-auto h-4 w-4" style={{ color: previewDarkMode ? '#000000' : '#ffffff' }} />
                         )}
                       </div>
                     </DropdownMenu.Item>


### PR DESCRIPTION
## Changes
- Added single "Open in" button with dropdown for V0, Lovable, and Bolt 
- Integrated Lovable with autosubmitted import prompt (preserves styles verbatim)
- Integrated Bolt with smart JSON handling (inline for small, clipboard for large)
- Updated UI to clean dropdown interface replacing three separate buttons
- Button defaults to "Open in V0" with logo + dropdown arrow
- All platforms use https://billingsdk.com/r/${registryName}.json for component data
- Preserves theme switching, dark mode toggle, and existing props/behavior

## How to Test
Steps to validate locally:
- Test dropdown button in preview:
1. V0 → should open instantly
2. Lovable → should open with prompt and preserve styles
3. Bolt → should handle small (inline) and large (clipboard) components