### PR TITLE
feat(banner): add destructive variant for banner component

### DIFF
--- a/content/docs/components/banner/index.mdx
+++ b/content/docs/components/banner/index.mdx
@@ -87,6 +87,21 @@ The banner component supports animated gradient backgrounds with custom colors. 
 
 </Tabs>
 
+## Destructive Banner
+
+<Tabs items={['Preview', 'Code']} className="bg-transparent border-none">
+  <Tab value="Preview" className="border-none bg-transparent p-0 mt-3">
+    <PreviewComponents registryName="banner">
+      <BannerDestructiveDemo />
+    </PreviewComponents>
+  </Tab>
+
+  <Tab value="Code" className="mt-3">
+  <include cwd lang="tsx" meta='title="src/components/banner-destructive-demo.tsx"'>src/components/banner-destructive-demo.tsx</include>
+  </Tab>
+
+</Tabs>
+
 
 
 ## Usage
@@ -143,6 +158,17 @@ import { Banner } from "@/components/billingsdk/banner";
 />
 ```
 
+```tsx
+// Destructive Banner
+<Banner
+  title="⚠️ Payment Failed - Subscription Suspended"
+  description="Your subscription will be canceled in 3 days if payment is not updated"
+  buttonText="Update Payment"
+  buttonLink="https://example.com/billing"
+  variant="destructive" // destructive
+/>
+```
+
 ## Props
 
 | Prop | Type | Required | Description |
@@ -153,7 +179,7 @@ import { Banner } from "@/components/billingsdk/banner";
 | `buttonText` | `string` | ❌ | The text of the button |
 | `buttonIcon` | `React.ReactNode` | ❌ | The icon of the button |
 | `buttonLink` | `string` | ❌ | The link of the button |
-| `variant` | `"default" \| "minimal" \| "popup"` | ✅ | The variant of the banner |
+| `variant` | `"default" \| "minimal" \| "popup" \| "destructive"` | ✅ | The variant of the banner |
 | `autoDismiss` | `number` | ❌ | The time in milliseconds to auto dismiss the banner |
 | `onDismiss` | `() => void` | ❌ | The function to call when the banner is dismissed |
 | `gradientColors` | `string[]` | ❌ | Array of color strings for animated gradient background |

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "ai": "^5.0.18",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "framer-motion": "^12.23.12",
         "fumadocs-core": "15.6.10",
         "fumadocs-mdx": "11.7.5",
         "fumadocs-ui": "15.6.10",
@@ -40,6 +41,7 @@
         "react-syntax-highlighter": "^15.6.1",
         "remark": "^15.0.1",
         "remark-gfm": "^4.0.1",
+        "remark-mdx": "^3.1.0",
         "remark-rehype": "^11.1.2",
         "tailwind-merge": "^3.3.1",
         "zod": "^4.0.17"
@@ -3969,7 +3971,7 @@
       "version": "19.1.10",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.10.tgz",
       "integrity": "sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -3979,7 +3981,7 @@
       "version": "19.1.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.7.tgz",
       "integrity": "sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -5181,7 +5183,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -11174,7 +11176,7 @@
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.11.tgz",
       "integrity": "sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/tapable": {

--- a/src/components/banner-destructive-demo.tsx
+++ b/src/components/banner-destructive-demo.tsx
@@ -1,0 +1,30 @@
+import { Banner } from "@/components/billingsdk/banner";
+
+export default function FreeTrialBannerDemo() {
+  return (
+    <div className="w-full h-full flex flex-col gap-6 min-h-[500px] rounded-lg overflow-hidden bg-background-secondary border-2">
+      <Banner
+        title="⚠️ Payment Failed - Subscription Suspended"
+        description="Your subscription will be canceled in 3 days if payment is not updated"
+        buttonText="Update Payment"
+        buttonLink="https://example.com/billing"
+        variant="destructive"
+      />
+
+      {/* minimal hero example */}
+      <section className="flex flex-col items-center justify-center text-center gap-4 py-16">
+        <h1 className="text-3xl font-bold tracking-tight text-foreground-secondary">
+          Create next-generation digital products
+        </h1>
+        <div className="flex flex-col gap-2">
+          <p className="text-muted-foreground max-w-md">
+            Build faster with our platform
+          </p>
+          <a className="underline underline-offset-4 hover:text-primary transition">
+            Get Started →
+          </a>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/components/billingsdk/banner.tsx
+++ b/src/components/billingsdk/banner.tsx
@@ -9,7 +9,7 @@ import { useState, useEffect } from "react"
 import { motion, AnimatePresence } from "motion/react"
 
 interface BannerProps {
-  variant?: "default" | "minimal" | "popup"
+  variant?: "default" | "minimal" | "popup" | "destructive"
   title: string
   description?: string
   buttonText?: string
@@ -74,6 +74,22 @@ export function Banner({
           title:"text-sm font-medium text-popover-foreground leading-snug",
           description:"text-xs text-muted-foreground",
           actions: "flex items-center gap-2 self-end sm:self-auto flex-shrink-0 pr-8",
+        }
+      case "destructive":
+        return {
+          container: hasGradient
+            ? "sticky top-0 z-50 w-full border-b border-destructive/20 backdrop-blur supports-[backdrop-filter]:bg-destructive/10"
+            : "sticky top-0 z-50 w-full border-b bg-destructive text-destructive-foreground shadow-sm backdrop-blur",
+          wrapper:
+            "relative container mx-auto flex flex-col sm:flex-row items-start sm:items-center justify-between px-3 sm:px-4 py-2 sm:py-3 gap-2 sm:gap-4",
+          content: "flex flex-col sm:flex-row items-start sm:items-center gap-2 w-full",
+          title: hasGradient
+            ? "text-sm font-medium text-destructive leading-tight"
+            : "text-sm font-medium text-destructive-foreground leading-tight",
+          description: hasGradient
+            ? "text-xs text-destructive/80"
+            : "text-xs text-destructive-foreground/80",
+          actions: "flex items-center gap-2 self-end sm:self-auto pr-8",
         }
       default:
         return {

--- a/src/mdx-components.tsx
+++ b/src/mdx-components.tsx
@@ -18,6 +18,7 @@ import BannerDemo from '@/components/banner-demo';
 import BannerGradientDemo from '@/components/banner-gradient-demo';
 import BannerDemoTwo from '@/components/banner-demo-two';
 import BannerDemoThree from '@/components/banner-demo-three';
+import BannerDestructiveDemo from '@/components/banner-destructive-demo';
 import CustomUsageMeterCircleDemo from '@/components/custom-usage-meter-circle-demo';
 import CustomUsageMeterLinearDemo from '@/components/custom-usage-meter-linear-demo';
 import InvoiceHistoryDemo from '@/components/invoice-history-demo';
@@ -47,6 +48,7 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     BannerDemoTwo,
     BannerDemoThree,
     BannerGradientDemo,
+    BannerDestructiveDemo,
     InvoiceHistoryDemo,
   };
 }

--- a/src/registry/billingsdk/banner.tsx
+++ b/src/registry/billingsdk/banner.tsx
@@ -9,7 +9,7 @@ import { useState, useEffect } from "react"
 import { motion, AnimatePresence } from "motion/react"
 
 interface BannerProps {
-  variant?: "default" | "minimal" | "popup"
+  variant?: "default" | "minimal" | "popup" | "destructive"
   title: string
   description?: string
   buttonText?: string
@@ -74,6 +74,22 @@ export function Banner({
           title:"text-sm font-medium text-popover-foreground leading-snug",
           description:"text-xs text-muted-foreground",
           actions: "flex items-center gap-2 self-end sm:self-auto flex-shrink-0 pr-8",
+        }
+      case "destructive":
+        return {
+          container: hasGradient
+            ? "sticky top-0 z-50 w-full border-b border-destructive/20 backdrop-blur supports-[backdrop-filter]:bg-destructive/10"
+            : "sticky top-0 z-50 w-full border-b bg-destructive text-destructive-foreground shadow-sm backdrop-blur",
+          wrapper:
+            "relative container mx-auto flex flex-col sm:flex-row items-start sm:items-center justify-between px-3 sm:px-4 py-2 sm:py-3 gap-2 sm:gap-4",
+          content: "flex flex-col sm:flex-row items-start sm:items-center gap-2 w-full",
+          title: hasGradient
+            ? "text-sm font-medium text-destructive leading-tight"
+            : "text-sm font-medium text-destructive-foreground leading-tight",
+          description: hasGradient
+            ? "text-xs text-destructive/80"
+            : "text-xs text-destructive-foreground/80",
+          actions: "flex items-center gap-2 self-end sm:self-auto pr-8",
         }
       default:
         return {


### PR DESCRIPTION
### Summary
adds a new `destructive` variant for critical notifications (like payment unsuccessful, failed to process, etc)

### Changes
- added a `destructive` field in the variant prop
- added a new case for destructive in `getVariantStyles` which returns the style for the same
- updated docs with a destructive banner and under the variant prop

### Screenshots/Recordings (if UI)

<img width="1833" height="973" alt="image" src="https://github.com/user-attachments/assets/28ddf6e8-7f1b-40b5-8ee9-adcee3eb0f78" />


### How to Test
Steps to validate locally:
1. npm ci
2. npm run typecheck
3. npm run build

### Checklist
- [x] Title is clear and descriptive
- [ ] Related issue linked (if any)
- [ ] Tests or manual verification steps included
- [ ] CI passes (typecheck & build)
- [x] Docs updated (if needed)

Note: I had also added a destructive variant under the Actions section for the button but honestly, it didn't look that great. Had tried to put outline variant for the button when the banner has a destructive variant

Let me know if there's any other change you'd like me to make. Cheers :)