### PR TITLE
fix: removed deprecated github (luclid icon) to react icon

### DIFF
--- a/src/app/docs/layout.tsx
+++ b/src/app/docs/layout.tsx
@@ -2,7 +2,7 @@ import { DocsLayout } from 'fumadocs-ui/layouts/docs';
 import type { ReactNode } from 'react';
 import { baseOptions } from '@/app/layout.config';
 import { source } from '@/lib/source';
-import { GithubIcon, FileTextIcon } from 'lucide-react';
+import { FaGithub, FaRegFileAlt  } from "react-icons/fa";
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (
@@ -16,11 +16,11 @@ export default function Layout({ children }: { children: ReactNode }) {
         text: 'llms-full.txt',
         url: '/llms-full.txt',
         active: 'none',
-        icon: <FileTextIcon />,
+        icon: <FaRegFileAlt />,
       },
       {
         type: 'icon',
-        icon: <GithubIcon />,
+        icon: <FaGithub />,
         text: 'GitHub',
         url: 'https://github.com/dodopayments/billingsdk',
       },

--- a/src/components/landing/NavBar.tsx
+++ b/src/components/landing/NavBar.tsx
@@ -2,10 +2,10 @@
 import Image from "next/image";
 import { Button } from "../ui/button";
 import Link from "next/link";
-import { Github } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useMotionValueEvent, useScroll } from "motion/react";
 import { useState } from "react";
+import { FaGithub } from "react-icons/fa";
 
 export const Logo = () => {
   return (
@@ -55,7 +55,7 @@ const NavBar = () => {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                <Github className="h-4 w-4" />
+                <FaGithub className="h-4 w-4" />
               </Link>
             </Button>
             <Button

--- a/src/components/landing/footer2.tsx
+++ b/src/components/landing/footer2.tsx
@@ -1,7 +1,8 @@
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
-import { Github, Heart } from "lucide-react";
 import { BsTwitterX } from "react-icons/bs";
+import { FaGithub, FaHeart } from "react-icons/fa";
+import Image from "next/image";
 
 export function Footer2() {
     return (
@@ -13,7 +14,7 @@ export function Footer2() {
                         <div className="lg:col-span-1">
                             <div className="flex items-center mb-4">
                                 <div className="flex items-center justify-center">
-                                    <img src="/logo/Logo.svg" alt="BillingSDK Logo" width="160" height="32" className="h-8 w-40" />
+                                    <Image src="/logo/Logo.svg" alt="BillingSDK Logo" width={160} height={32} className="h-8 w-40" />
                                 </div>
                             </div>
                             <p className="text-sm text-muted-foreground mb-4">
@@ -22,12 +23,12 @@ export function Footer2() {
                             <div className="flex">
                                 <Button variant="ghost" size="sm" asChild>
                                     <Link href="https://github.com/dodopayments/billingsdk" target="_blank" rel="noopener noreferrer">
-                                        <Github className="h-4 w-4" />
+                                        <FaGithub className="h-4 w-4" />
                                     </Link>
                                 </Button>
                                 <Button variant="ghost" size="sm" asChild>
                                     <Link href="https://dodopayments.com/" target="_blank" rel="noopener noreferrer">
-                                        <img src="/logo/logo-dodo.svg" alt="Dodo Payments" width="16" height="16" className="h-4 w-4" />
+                                        <Image src="/logo/logo-dodo.svg" alt="Dodo Payments" width={16} height={16} className="h-4 w-4" />
 
                                     </Link>
                                 </Button>
@@ -124,7 +125,7 @@ export function Footer2() {
                             <div className="flex flex-col md:flex-row items-center gap-4 mb-4 md:mb-0">
                                 <p className="text-sm text-muted-foreground">
                                     © {new Date().getFullYear()} BillingSDK. Made with{" "}
-                                    <Heart className="inline h-3 w-3 text-red-500 fill-current" />{" "}
+                                    <FaHeart className="inline h-3 w-3 text-red-500 fill-current" />{" "}
                                     by developers at Dodo Payments, for developers.
                                 </p>
                             </div>


### PR DESCRIPTION
### Summary
removed the deprecated github icon which was using lucide react and switched to react icons.
also in my prev pr i optimized the image in the footer but that contribution got reverted so reapplied it once again.

### Changes
- switched from deprecated github icon to new react icon for github and file text.

### Screenshots/Recordings (if UI)
before:
<img width="121" height="65" alt="Screenshot 2025-08-29 at 6 42 55 PM" src="https://github.com/user-attachments/assets/86f7a8e0-c184-4a84-b841-86968a2a1027" />
<img width="241" height="104" alt="Screenshot 2025-08-29 at 6 43 28 PM" src="https://github.com/user-attachments/assets/76d63c01-ac9f-4ec4-a144-aa9c8a3dc799" />
<img width="354" height="207" alt="Screenshot 2025-08-29 at 6 43 44 PM" src="https://github.com/user-attachments/assets/48e015ca-4dd7-4789-b24e-165dde87af00" />

after:
<img width="105" height="69" alt="Screenshot 2025-08-29 at 6 44 02 PM" src="https://github.com/user-attachments/assets/232bbdb7-db3a-4a35-bd7b-d5e3b32db9eb" />
<img width="217" height="83" alt="Screenshot 2025-08-29 at 6 44 29 PM" src="https://github.com/user-attachments/assets/b15a0c98-9db5-4444-bd8c-b56eeae908d8" />
<img width="413" height="193" alt="Screenshot 2025-08-29 at 6 44 40 PM" src="https://github.com/user-attachments/assets/95d71b28-8357-4a9e-841f-9b66f002523c" />



### How to Test
Steps to validate locally:
1. npm ci
2. npm run typecheck
3. npm run build

### Checklist
- [x] Title is clear and descriptive
- [ ] Related issue linked (if any)
- [ ] Tests or manual verification steps included
- [x] CI passes (typecheck & build)
- [x] Docs updated (if needed)

