### PR TITLE
fix: Icon alignment within pricing-table-one

### DIFF
--- a/src/registry/billingsdk/pricing-table-one.tsx
+++ b/src/registry/billingsdk/pricing-table-one.tsx
@@ -123,7 +123,7 @@ const priceTextVariants = cva("font-medium", {
   },
 });
 
-const featureIconVariants = cva("", {
+const featureIconVariants = cva("flex-none h-[1lh]", {
   variants: {
     size: {
       small: "size-3",
@@ -385,7 +385,7 @@ export function PricingTableOne({
                     {plan.features.map((feature, featureIndex) => (
                       <motion.li 
                         key={featureIndex} 
-                        className="flex items-center gap-3"
+                        className="flex gap-3"
                         initial={{ opacity: 0, x: -10 }}
                         animate={{ opacity: 1, x: 0 }}
                         transition={{ duration: 0.3, delay: featureIndex * 0.05 }}


### PR DESCRIPTION
### Summary
- Fixes issues where the icon within the list items were not properly aligned to the first line when the text wraps.
- Fixes issue where the check icon would shrink with multi line items

This could also be ported to the other pricing table components. Feel free to make edits directly to the PR if you want!

### Changes
- Key changes in this PR

### Screenshots/Recordings (if UI)
| BEFORE | AFTER |
|--------|--------|
| <img width="374" height="163" alt="Screenshot 2025-09-06 at 9 30 02 AM" src="https://github.com/user-attachments/assets/4f248942-a84b-41ab-837e-db7c6206b030" /> | <img width="357" height="146" alt="Screenshot 2025-09-06 at 9 30 43 AM" src="https://github.com/user-attachments/assets/19219a5b-3f2c-4646-8656-015c4fd95be8" /> |

### How to Test
Steps to validate locally:
1. npm ci
2. npm run typecheck
3. npm run build

### Checklist
- [ ] Title is clear and descriptive
- [ ] Related issue linked (if any)
- [ ] Tests or manual verification steps included
- [ ] CI passes (typecheck & build)
- [ ] Docs updated (if needed)

