### PR TITLE
feat(cli): add framework auto-detection for init command

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@clack/prompts": "^0.11.0",
         "commander": "^14.0.0",
+        "find-up": "^7.0.0",
         "ink": "^6.2.3",
         "ink-big-text": "^2.0.0",
         "react": "^19.1.1",
@@ -1266,6 +1267,23 @@
         }
       }
     },
+    "node_modules/find-up": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-7.0.0.tgz",
+      "integrity": "sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^7.2.0",
+        "path-exists": "^5.0.0",
+        "unicorn-magic": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fix-dts-default-cjs-exports": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
@@ -1721,6 +1739,21 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
+    "node_modules/locate-path": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
+      "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^6.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -1825,6 +1858,36 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/p-limit": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -1835,6 +1898,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
       "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -2450,6 +2522,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unicorn-magic": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
@@ -2646,6 +2730,18 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
+      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/yoga-layout": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@clack/prompts": "^0.11.0",
     "commander": "^14.0.0",
+    "find-up": "^7.0.0",
     "ink": "^6.2.3",
     "ink-big-text": "^2.0.0",
     "react": "^19.1.1",

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import { intro, outro, select, spinner } from "@clack/prompts";
 import { addFiles } from "../scripts/add-files.js";
+import { detectFramework } from "../scripts/detect-framework.js";
 
 export const initCommand = new Command()
   .name("init")
@@ -10,13 +11,18 @@ export const initCommand = new Command()
     try {
       intro("Welcome to Billing SDK Setup!");
 
-      const framework = await select({
-        message: "Which framework would you like to use?",
-        options: [
-          { value: "nextjs", label: "Next.js", hint: "React framework with App Router" },
-          { value: "express", label: "Express.js", hint: "Node.js web framework" },
-        ],
-      });
+      let framework = detectFramework()
+      if (!framework) {
+        framework = await select({
+          message: "Which framework would you like to use?",
+          options: [
+            { value: "nextjs", label: "Next.js", hint: "React framework with App Router" },
+            { value: "express", label: "Express.js", hint: "Node.js web framework" },
+          ],
+        }) as 'nextjs' | 'express'
+      } else {
+        intro(`Framework detected: ${framework}`) // framework is detected in the same directory or in parent dir
+      }
 
       const provider = await select({
         message: "Which payment provider would you like to use? (Adding more providers soon)",

--- a/packages/cli/src/scripts/detect-framework.ts
+++ b/packages/cli/src/scripts/detect-framework.ts
@@ -1,0 +1,21 @@
+import fs from "fs";
+import { findUpSync } from "find-up"; // find a directory by walking up parent directories
+
+export const detectFramework = (): "nextjs" | "express" | null => {
+    try {
+
+        const pkgPath = findUpSync("package.json")
+        if (!pkgPath) return null
+        const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8"))
+
+        if (pkg.dependencies?.next || pkg.devDependencies?.next) {
+            return "nextjs"
+        }
+        if (pkg.dependencies?.express || pkg.devDependencies?.express) {
+            return "express"
+        }
+        return null;
+    } catch {
+        return null
+    }
+}


### PR DESCRIPTION
fix #105 

### Summary
This PR introduces automatic framework detection to the CLI `init` command.  
Instead of always prompting the user, the CLI now:
- Detects if the project is using **Next.js** or **Express** by checking `package.json`.
- Prefills the framework automatically when detected.
- Falls back to prompting the user if no supported framework is found.
### Changes
- Added a new utility `detect-framework.ts` under `scripts/`.
- Integrated framework detection into `init.ts` before showing the framework prompt.
- Installed [`find-up`](https://www.npmjs.com/package/find-up) to safely locate `package.json` when running the CLI from nested directories.

### Screenshots/Recordings (if UI)

https://github.com/user-attachments/assets/410b9076-e80b-41a4-85f8-f9e22ce1c30f


### How to Test
Steps to validate locally:
1. npm ci
2. npm run typecheck
3. npm run build

### Checklist
- [x] Title is clear and descriptive
- [x] Related issue linked (if any)
- [x] Tests or manual verification steps included
- [x] CI passes (typecheck & build)
- [ ] Docs updated (if needed)

