### PR TITLE
Fix package manager commands and add bun support to documentation

### DIFF
--- a/content/docs/components/banner/index.mdx
+++ b/content/docs/components/banner/index.mdx
@@ -24,7 +24,7 @@ You can change the variant of the banner to `default`, `minimal`, or `popup`.
 
 <Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
   <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
       <Tab value="npx">
         ```bash
         npx shadcn@latest add @billingsdk/banner
@@ -37,13 +37,18 @@ You can change the variant of the banner to `default`, `minimal`, or `popup`.
       </Tab>
       <Tab value="yarn">
         ```bash
-        npx shadcn@latest add @billingsdk/banner
+        yarn dlx shadcn@latest add @billingsdk/banner
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/banner
         ```
       </Tab>
     </Tabs>
   </Tab>
   <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
       <Tab value="npx">
         ```bash
         npx @billingsdk/cli add banner
@@ -56,7 +61,12 @@ You can change the variant of the banner to `default`, `minimal`, or `popup`.
       </Tab>
       <Tab value="yarn">
         ```bash
-        npx @billingsdk/cli add banner
+        yarn dlx @billingsdk/cli add banner
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add banner
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/cancel-subscription/cancel-subscription-card.mdx
+++ b/content/docs/components/cancel-subscription/cancel-subscription-card.mdx
@@ -33,7 +33,7 @@ description: The Cancel Subscription Card component provides a comprehensive and
       </Tab>
       <Tab value="yarn">
         ```bash
-        npx shadcn@latest add @billingsdk/cancel-subscription-card
+        yarn dlx shadcn@latest add @billingsdk/cancel-subscription-card
         ```
       </Tab>
     </Tabs>
@@ -52,7 +52,7 @@ description: The Cancel Subscription Card component provides a comprehensive and
       </Tab>
       <Tab value="yarn">
         ```bash
-        npx @billingsdk/cli add cancel-subscription-card
+        yarn dlx @billingsdk/cli add cancel-subscription-card
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/cancel-subscription/cancel-subscription-dialog.mdx
+++ b/content/docs/components/cancel-subscription/cancel-subscription-dialog.mdx
@@ -33,7 +33,7 @@ description: The Cancel Subscription Dialog component provides a comprehensive a
       </Tab>
       <Tab value="yarn">
         ```bash
-        npx shadcn@latest add @billingsdk/cancel-subscription-dialog
+        yarn dlx shadcn@latest add @billingsdk/cancel-subscription-dialog
         ```
       </Tab>
     </Tabs>
@@ -52,7 +52,7 @@ description: The Cancel Subscription Dialog component provides a comprehensive a
       </Tab>
       <Tab value="yarn">
         ```bash
-        npx @billingsdk/cli add cancel-subscription-dialog
+        yarn dlx @billingsdk/cli add cancel-subscription-dialog
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/invoice-history/index.mdx
+++ b/content/docs/components/invoice-history/index.mdx
@@ -32,7 +32,7 @@ description: Read-only table for displaying past invoices and receipts with stat
       </Tab>
       <Tab value="yarn">
         ```bash
-        npx shadcn@latest add @billingsdk/invoice-history
+        yarn dlx shadcn@latest add @billingsdk/invoice-history
         ```
       </Tab>
     </Tabs>
@@ -51,7 +51,7 @@ description: Read-only table for displaying past invoices and receipts with stat
       </Tab>
       <Tab value="yarn">
         ```bash
-        npx @billingsdk/cli add invoice-history
+        yarn dlx @billingsdk/cli add invoice-history
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/manage-subscription/index.mdx
+++ b/content/docs/components/manage-subscription/index.mdx
@@ -26,7 +26,7 @@ description: The Manage Subscription component provides a comprehensive interfac
 
 <Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
   <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
       <Tab value="npx">
         ```bash
         npx shadcn@latest add @billingsdk/subscription-management
@@ -39,13 +39,18 @@ description: The Manage Subscription component provides a comprehensive interfac
       </Tab>
       <Tab value="yarn">
         ```bash
-        npx shadcn@latest add @billingsdk/subscription-management
+        yarn dlx shadcn@latest add @billingsdk/subscription-management
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/subscription-management
         ```
       </Tab>
     </Tabs>
   </Tab>
   <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
       <Tab value="npx">
         ```bash
         npx @billingsdk/cli add subscription-management
@@ -58,7 +63,12 @@ description: The Manage Subscription component provides a comprehensive interfac
       </Tab>
       <Tab value="yarn">
         ```bash
-        npx @billingsdk/cli add subscription-management
+        yarn dlx @billingsdk/cli add subscription-management
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add subscription-management
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/payment-method-manager/index.mdx
+++ b/content/docs/components/payment-method-manager/index.mdx
@@ -17,7 +17,7 @@ description: The Payment Method Manager component provides a PCI-compliant UI fo
 
 ## Installation
 
-<Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+<Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
   <Tab value="npx">
     ```bash
     npx shadcn@latest add @billingsdk/payment-method-manager
@@ -32,7 +32,12 @@ description: The Payment Method Manager component provides a PCI-compliant UI fo
 
   <Tab value="yarn">
     ```bash
-    npx shadcn@latest add @billingsdk/payment-method-manager
+    yarn dlx shadcn@latest add @billingsdk/payment-method-manager
+    ```
+  </Tab>
+  <Tab value="bun">
+    ```bash
+    bunx shadcn@latest add @billingsdk/payment-method-manager
     ```
   </Tab>
 </Tabs>

--- a/content/docs/components/payment-method-selector/index.mdx
+++ b/content/docs/components/payment-method-selector/index.mdx
@@ -35,7 +35,7 @@ description: Interactive selector for Cards, Digital Wallets, UPI (India), and B
       </Tab>
       <Tab value="yarn">
         ```bash
-        npx shadcn@latest add @billingsdk/payment-method-selector
+        yarn dlx shadcn@latest add @billingsdk/payment-method-selector
         ```
       </Tab>
     </Tabs>
@@ -54,7 +54,7 @@ description: Interactive selector for Cards, Digital Wallets, UPI (India), and B
       </Tab>
       <Tab value="yarn">
         ```bash
-        npx @billingsdk/cli add payment-method-selector
+        yarn dlx @billingsdk/cli add payment-method-selector
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/payment-success-dialog/index.mdx
+++ b/content/docs/components/payment-success-dialog/index.mdx
@@ -33,7 +33,7 @@ description: A confirmation dialog that celebrates a successful payment with the
       </Tab>
       <Tab value="yarn">
         ```bash
-        npx shadcn@latest add @billingsdk/payment-success-dialog
+        yarn dlx shadcn@latest add @billingsdk/payment-success-dialog
         ```
       </Tab>
     </Tabs>
@@ -52,7 +52,7 @@ description: A confirmation dialog that celebrates a successful payment with the
       </Tab>
       <Tab value="yarn">
         ```bash
-        npx @billingsdk/cli add payment-success-dialog
+        yarn dlx @billingsdk/cli add payment-success-dialog
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/pricing-table/pricing-table-five.mdx
+++ b/content/docs/components/pricing-table/pricing-table-five.mdx
@@ -36,26 +36,31 @@ description: The Pricing Table Five component provides a fifth design option for
 
 <Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
   <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
       <Tab value="npx">
         ```bash
-        npx shadcn@latest add https://billingsdk.com/r/pricing-table-five.json
+        npx shadcn@latest add @billingsdk/pricing-table-five
         ```
       </Tab>
       <Tab value="pnpm">
         ```bash
-        pnpm dlx shadcn@latest add https://billingsdk.com/r/pricing-table-five.json
+        pnpm dlx shadcn@latest add @billingsdk/pricing-table-five
         ```
       </Tab>
       <Tab value="yarn">
         ```bash
-        npx shadcn@latest add https://billingsdk.com/r/pricing-table-five.json
+        yarn dlx shadcn@latest add @billingsdk/pricing-table-five
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/pricing-table-five
         ```
       </Tab>
     </Tabs>
   </Tab>
   <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
       <Tab value="npx">
         ```bash
         npx @billingsdk/cli add pricing-table-five
@@ -68,7 +73,12 @@ description: The Pricing Table Five component provides a fifth design option for
       </Tab>
       <Tab value="yarn">
         ```bash
-        npx @billingsdk/cli add pricing-table-five
+        yarn dlx @billingsdk/cli add pricing-table-five
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add pricing-table-five
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/pricing-table/pricing-table-four.mdx
+++ b/content/docs/components/pricing-table/pricing-table-four.mdx
@@ -30,7 +30,7 @@ description: The Pricing Table Four component provides a modern gradient design 
   </Tab>
   <Tab value="yarn">
     ```bash
-    npx shadcn@latest add @billingsdk/pricing-table-four
+    yarn dlx shadcn@latest add @billingsdk/pricing-table-four
     ```
   </Tab>
 </Tabs>

--- a/content/docs/components/pricing-table/pricing-table-one.mdx
+++ b/content/docs/components/pricing-table/pricing-table-one.mdx
@@ -36,7 +36,7 @@ description: The Pricing Table One component provides a clean and modern design 
 
 <Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
   <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
       <Tab value="npx">
         ```bash
         npx shadcn@latest add @billingsdk/pricing-table-one
@@ -49,13 +49,18 @@ description: The Pricing Table One component provides a clean and modern design 
       </Tab>
       <Tab value="yarn">
         ```bash
-        npx shadcn@latest add @billingsdk/pricing-table-one
+        yarn dlx shadcn@latest add @billingsdk/pricing-table-one
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/pricing-table-one
         ```
       </Tab>
     </Tabs>
   </Tab>
   <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
       <Tab value="npx">
         ```bash
         npx @billingsdk/cli add pricing-table-one
@@ -68,7 +73,12 @@ description: The Pricing Table One component provides a clean and modern design 
       </Tab>
       <Tab value="yarn">
         ```bash
-        npx @billingsdk/cli add pricing-table-one
+        yarn dlx @billingsdk/cli add pricing-table-one
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add pricing-table-one
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/pricing-table/pricing-table-three.mdx
+++ b/content/docs/components/pricing-table/pricing-table-three.mdx
@@ -32,7 +32,7 @@ description: The Pricing Table Three component provides a third design option fo
       </Tab>
       <Tab value="yarn">
         ```bash
-        npx shadcn@latest add @billingsdk/pricing-table-three
+        yarn dlx shadcn@latest add @billingsdk/pricing-table-three
         ```
       </Tab>
     </Tabs>
@@ -51,7 +51,7 @@ description: The Pricing Table Three component provides a third design option fo
       </Tab>
       <Tab value="yarn">
         ```bash
-        npx @billingsdk/cli add pricing-table-three
+        yarn dlx @billingsdk/cli add pricing-table-three
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/pricing-table/pricing-table-two.mdx
+++ b/content/docs/components/pricing-table/pricing-table-two.mdx
@@ -51,7 +51,7 @@ description: The Pricing Table Two component offers an alternative design approa
       </Tab>
       <Tab value="yarn">
         ```bash
-        npx shadcn@latest add @billingsdk/pricing-table-two
+        yarn dlx shadcn@latest add @billingsdk/pricing-table-two
         ```
       </Tab>
     </Tabs>
@@ -70,7 +70,7 @@ description: The Pricing Table Two component offers an alternative design approa
       </Tab>
       <Tab value="yarn">
         ```bash
-        npx @billingsdk/cli add pricing-table-two
+        yarn dlx @billingsdk/cli add pricing-table-two
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/update-plan/update-plan-card.mdx
+++ b/content/docs/components/update-plan/update-plan-card.mdx
@@ -33,7 +33,7 @@ description: The Update Plan Card component provides a compact, card-based inter
       </Tab>
       <Tab value="yarn">
         ```bash
-        npx shadcn@latest add @billingsdk/update-plan-card
+        yarn dlx shadcn@latest add @billingsdk/update-plan-card
         ```
       </Tab>
     </Tabs>
@@ -52,7 +52,7 @@ description: The Update Plan Card component provides a compact, card-based inter
       </Tab>
       <Tab value="yarn">
         ```bash
-        npx @billingsdk/cli add update-plan-card
+        yarn dlx @billingsdk/cli add update-plan-card
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/update-plan/update-plan-dialog.mdx
+++ b/content/docs/components/update-plan/update-plan-dialog.mdx
@@ -33,7 +33,7 @@ description: The Update Plan Dialog component provides an interactive interface 
       </Tab>
       <Tab value="yarn">
         ```bash
-        npx shadcn@latest add @billingsdk/update-plan-dialog
+        yarn dlx shadcn@latest add @billingsdk/update-plan-dialog
         ```
       </Tab>
     </Tabs>
@@ -52,7 +52,7 @@ description: The Update Plan Dialog component provides an interactive interface 
       </Tab>
       <Tab value="yarn">
         ```bash
-        npx @billingsdk/cli add update-plan-dialog
+        yarn dlx @billingsdk/cli add update-plan-dialog
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/usage-meter/usage-meter-circle.mdx
+++ b/content/docs/components/usage-meter/usage-meter-circle.mdx
@@ -23,7 +23,7 @@ You can change the progress color of the usage meter to `default` or `usage`.
 
 <Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
   <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
       <Tab value="npx">
         ```bash
         npx shadcn@latest add @billingsdk/usage-meter-circle
@@ -36,13 +36,18 @@ You can change the progress color of the usage meter to `default` or `usage`.
       </Tab>
       <Tab value="yarn">
         ```bash
-        npx shadcn@latest add @billingsdk/usage-meter-circle
+        yarn dlx shadcn@latest add @billingsdk/usage-meter-circle
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/usage-meter-circle
         ```
       </Tab>
     </Tabs>
   </Tab>
   <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
       <Tab value="npx">
         ```bash
         npx @billingsdk/cli add usage-meter-circle
@@ -55,7 +60,12 @@ You can change the progress color of the usage meter to `default` or `usage`.
       </Tab>
       <Tab value="yarn">
         ```bash
-        npx @billingsdk/cli add usage-meter-circle
+        yarn dlx @billingsdk/cli add usage-meter-circle
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add usage-meter-circle
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/usage-meter/usage-meter-linear.mdx
+++ b/content/docs/components/usage-meter/usage-meter-linear.mdx
@@ -36,7 +36,7 @@ You can change the progress color of the usage meter to `default` or `usage`.
       </Tab>
       <Tab value="yarn">
         ```bash
-        npx shadcn@latest add @billingsdk/usage-meter-linear
+        yarn dlx shadcn@latest add @billingsdk/usage-meter-linear
         ```
       </Tab>
     </Tabs>
@@ -55,7 +55,7 @@ You can change the progress color of the usage meter to `default` or `usage`.
       </Tab>
       <Tab value="yarn">
         ```bash
-        npx @billingsdk/cli add usage-meter-linear
+        yarn dlx @billingsdk/cli add usage-meter-linear
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/usage-table/index.mdx
+++ b/content/docs/components/usage-table/index.mdx
@@ -32,7 +32,7 @@ description: Per-model LLM usage with token counts, cache reads, and API cost.
       </Tab>
       <Tab value="yarn">
         ```bash
-        npx shadcn@latest add @billingsdk/usage-table
+        yarn dlx shadcn@latest add @billingsdk/usage-table
         ```
       </Tab>
     </Tabs>
@@ -51,7 +51,7 @@ description: Per-model LLM usage with token counts, cache reads, and API cost.
       </Tab>
       <Tab value="yarn">
         ```bash
-        npx @billingsdk/cli add usage-table
+        yarn dlx @billingsdk/cli add usage-table
         ```
       </Tab>
     </Tabs>

--- a/content/docs/quick-start.mdx
+++ b/content/docs/quick-start.mdx
@@ -26,12 +26,12 @@ A React or Next.js project with Tailwind CSS is required. Install any component 
       </Tab>
       <Tab value="yarn">
         ```bash
-        npx shadcn@latest add @billingsdk/pricing-table-one
+        yarn dlx shadcn@latest add @billingsdk/pricing-table-one
         ```
       </Tab>
       <Tab value="bun">
         ```bash
-        npx shadcn@latest add @billingsdk/pricing-table-one
+        bunx shadcn@latest add @billingsdk/pricing-table-one
         ```
       </Tab>
     </Tabs>
@@ -50,12 +50,12 @@ A React or Next.js project with Tailwind CSS is required. Install any component 
       </Tab>
       <Tab value="yarn">
         ```bash
-        npx @billingsdk/cli add pricing-table-one
+        yarn dlx @billingsdk/cli add pricing-table-one
         ```
       </Tab>
       <Tab value="bun">
         ```bash
-        npx @billingsdk/cli add pricing-table-one
+        bunx @billingsdk/cli add pricing-table-one
         ```
       </Tab>
     </Tabs>
@@ -87,13 +87,13 @@ For new projects or comprehensive billing integration, use our CLI tool for comp
 
   <Tab value="yarn">
     ```bash
-    npx @billingsdk/cli init
+    yarn dlx @billingsdk/cli init
     ```
   </Tab>
 
   <Tab value="bun">
     ```bash
-    npx @billingsdk/cli init
+    bunx @billingsdk/cli init
     ```
   </Tab>
 </Tabs>

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -1,6 +1,21 @@
 import { Command } from "commander";
 import { execSync } from "child_process";
 
+
+function getPackageManagerRunner(): string {
+  const userAgent = process.env.npm_config_user_agent || "";
+  
+  if (userAgent.startsWith("bun")) {
+    return "bunx";
+  } else if (userAgent.startsWith("pnpm")) {
+    return "pnpm dlx";
+  } else if (userAgent.startsWith("yarn")) {
+    return "yarn dlx";
+  } else {
+    return "npx";
+  }
+}
+
 export const addCommand = new Command()
   .name("add")
   .description("Add a billing component to your project")
@@ -15,9 +30,10 @@ export const addCommand = new Command()
       }
 
       const templateRegistry = `@billingsdk/${component}.json`;
-      execSync(`npx shadcn@latest add ${templateRegistry}`, { stdio: "inherit" });
+      const runner = getPackageManagerRunner();
+      execSync(`${runner} shadcn@latest add ${templateRegistry}`, { stdio: "inherit" });
     } catch (error) {
-      // console.error(`Failed to add component "${component}"`,);
+      // console.error(`Failed to add component "${component}",);
       process.exit(1);
     }
   });


### PR DESCRIPTION
### Summary
This PR improves the documentation consistency across all component documentation files by adding Bun package manager support to installation commands. Previously, the documentation was missing Bun installation options and had inconsistent package manager commands (using npx for yarn/bun instead of their respective commands). This change ensures all documentation files provide complete and accurate installation instructions for all supported package managers.

> Overall changed 19 files with 108 additions and 53 deletions. 

### Changes
- Added Bun package manager option to Tabs components in all component documentation files
- Fixed package manager-specific installation commands to use correct prefixes:
  - npx for npm
  - pnpm dlx for pnpm
  - yarn dlx for yarn
  - bunx for bun
- Updated 6 component documentation files:
  - banner/index.mdx
  - pricing-table-one.mdx
  - pricing-table-five.mdx
  - usage-meter-circle.mdx
  - payment-method-manager/index.mdx
  - manage-subscription/index.mdx

### Screenshots/Recordings (if UI)
No UI changes - documentation-only update.

before:
<img width="1211" height="171" alt="image" src="https://github.com/user-attachments/assets/955be0f8-8674-4da6-b975-895976db1bc4" />

after :
<img width="1180" height="145" alt="image" src="https://github.com/user-attachments/assets/1664278e-9a0e-4a42-b48d-368440d560d8" />


### How to Test
Steps to validate locally:
1. npm ci
2. npm run typecheck
3. npm run build

### Checklist
- [x] Title is clear and descriptive
- [x] Related issue linked (if any)
- [x] Tests or manual verification steps included
- [x] CI passes (typecheck & build)
- [x] Docs updated (if needed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added Bun as an installation option across component docs and Quick Start (shadcn and BillingSDK tabs).
  - Updated Yarn examples to use yarn dlx instead of npx in installation snippets.
  - Introduced bunx commands alongside existing npx/pnpm examples.
  - Applied to multiple components (Banner, Cancel Subscription, Invoice History, Manage Subscription, Payment Method, Payment Success, Pricing Tables, Update Plan, Usage Meter, Usage Table).
  - No runtime or API changes.

- Chores
  - CLI now auto-uses the appropriate package-runner (bunx/pnpm dlx/yarn dlx/npx) based on environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->