### PR TITLE
chore(release): bump CLI version to 0.7.0

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@billingsdk/cli",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@billingsdk/cli",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "dependencies": {
         "@clack/prompts": "^0.11.0",
         "commander": "^14.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@billingsdk/cli",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/dodopayments/billingsdk.git"


### PR DESCRIPTION
This pull request updates the version of the `@billingsdk/cli` package from `0.6.0` to `0.7.0` in both the `package.json` and `package-lock.json` files. No other changes are included.

* Bump version number in `package.json` to `0.7.0`
* Bump version number in `package-lock.json` to `0.7.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated CLI package version to 0.7.0 for release distribution.
  - No functional changes: commands, flags, and behavior remain unchanged.
  - Ensures package managers recognize the latest release and aligns published metadata with the new version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->