### PR TITLE
fix: return 400 status for webhook verification failures instead of 200

### DIFF
--- a/packages/templates/nextjs/api-routes/(dodopayments)/webhook/route.ts
+++ b/packages/templates/nextjs/api-routes/(dodopayments)/webhook/route.ts
@@ -52,11 +52,11 @@ export async function POST(request: Request) {
       { status: 200 }
     );
   } catch (error) {
-    console.log(" ----- webhoook verification failed -----")
+    console.log(" ----- webhook verification failed -----")
     console.log(error)
     return Response.json(
-      { message: "Webhook processed successfully" },
-      { status: 200 }
+      { message: "Webhook verification failed" },
+      { status: 400 }
     );
   }
 }


### PR DESCRIPTION
### Summary
Closes #186 
Fix incorrect error handling in Next.js webhook template that was returning HTTP 200 success status for webhook verification failures instead of proper 400 error status.

### Changes
- Changed webhook verification failure response status from `200` to `400`
- Updated error message from "Webhook processed successfully" to "Webhook verification failed"
- Fixed typo in console log: "webhoook" → "webhook"

### Screenshots/Recordings (if UI)
N/A - Backend API change only

### How to Test
Steps to validate locally:
1. npm ci
2. npm run typecheck
3. npm run build
4. Verify webhook route at `packages/templates/nextjs/api-routes/(dodopayments)/webhook/route.ts` returns 400 status in catch block

### Checklist
- [x] Title is clear and descriptive
- [x] Related issue linked (if any) - Fixes #186
- [x] Tests or manual verification steps included
- [x] CI passes (typecheck & build)
- [x] Docs updated (if needed) - No docs update needed for template fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook endpoint now correctly returns HTTP 400 with message “Webhook verification failed” when verification fails, instead of an incorrect 200 success response. This ensures clients can reliably detect and handle failures.
  * Corrected a typo in the failure log message for clearer diagnostics.

* **Chores**
  * Minor logging polish to improve readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->