### PR TITLE
Playground Button Fix

### DIFF
--- a/src/components/page-actions.tsx
+++ b/src/components/page-actions.tsx
@@ -321,7 +321,7 @@ function PlaygroundButton({
       className={cn(
         buttonVariants({
           variant: 'secondary',
-          className: 'gap-2 [&_svg]:size-3.5 [&_svg]:text-fd-muted-foreground rounded-none',
+          className: 'gap-2 [&_svg]:size-3.5 [&_svg]:text-fd-muted-foreground rounded-md',
         }),
       )}
       onClick={(e) => {


### PR DESCRIPTION
This makes the Playground button’s corners match the Copy Page button styling.

before - 
<img width="393" height="81" alt="image" src="https://github.com/user-attachments/assets/6b2ec10b-836b-4c09-9171-e6b8c66c09b3" />

After 
<img width="427" height="67" alt="image" src="https://github.com/user-attachments/assets/2cd5a154-e277-424b-9b3b-b2f7a117312e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Playground button in page actions to use rounded corners instead of sharp edges, improving visual polish and consistency with the rest of the interface.
  * Refined the button’s border radius to rounded-medium, offering a softer look that aligns with current design guidelines.
  * No changes to behavior or functionality; this update is purely cosmetic and should not impact workflows or interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->