### PR TITLE
feat(ui): Make navbar logo clickable to navigate home ("/")

### DIFF
--- a/src/components/landing/NavBar.tsx
+++ b/src/components/landing/NavBar.tsx
@@ -10,6 +10,7 @@ import GitHubStarBadge from "./GitHubStarBadge";
 
 export const Logo = () => {
   return (
+    <Link href="/" className="cursor-pointer">
     <div className="flex items-center justify-center gap-2">
       <Image
         src="/logo/logo-dodo.svg"
@@ -20,6 +21,8 @@ export const Logo = () => {
       <span className="text-3xl font-display">/</span>
       <Image src="/logo/Logo.svg" alt="Billing SDK" width={120} height={120} />
     </div>
+    </Link>
+    
   );
 };
 


### PR DESCRIPTION
### Summary
Add navigation functionality to the navbar logo to enable homepage navigation when clicked. Small contribution because apparently someone forgot that logos are supposed to be clickable 🤷‍♂️

### Recordings

**Before:**

https://github.com/user-attachments/assets/28566ce9-7c53-43c6-ae3a-bb6b0e01186b

**After:**

https://github.com/user-attachments/assets/407ee257-55b5-4384-af74-9dafbaf6871c

### Changes
- Wrapped `Logo` component with Next.js `Link` component in `src/components/landing/NavBar.tsx`
- Added `href="/"` for homepage navigation
- Added Cursor Pointer (`cursor-pointer`) for better user feedback
- Maintained existing styling and accessibility

### How to Test
1. `npm run dev`
2. Navigate to any section (footer, docs, etc.)
3. Click the logo in navbar
4. Verify it smoothly navigates back to homepage
5. Test hover effects show visual feedback

### Checklist
- [x] Title is clear and descriptive
- [x] Tests or manual verification steps included
- [x] Fixed a basic UX pattern that was mysteriously missing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The logo in the navigation bar is now clickable and takes you directly to the homepage from anywhere in the app. This creates a more intuitive navigation experience by aligning with common web conventions and making it easier to return home without using the back button or menu links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->