### PR TITLE
fix: improve UI consistency in Cancel Subscription Card Two

### DIFF
--- a/src/components/cancel-subscription-card-two-demo.tsx
+++ b/src/components/cancel-subscription-card-two-demo.tsx
@@ -6,38 +6,37 @@ import { plans } from "@/lib/billingsdk-config";
 
 export function CancelSubscriptionCardTwoDemo() {
     return(
-    <div className="flex flex-1 flex-col justify-center text-center p-2 min-h-[200px]">
-    <CancelSubscriptionCardTwo
-    title="We're sorry to see you go..."
-    description={`Before you cancel, we hope you'll consider upgrading to a ${plans[1].title} plan again.`}
-    plan={plans[1]}
-    warningText="If you cancel your subscription, you will lose access to your account and all your data will be deleted."
-    supportText="Need help? Our team is here to assist you."
-    supportLink="https://google.com/"
-    finalTitle="Final Step - Confirm Cancellation"
-    finalSubtitle="You'll lose access to all Pro features and your data will be permanently deleted after 30 days."
-    keepButtonText={`Keep My ${plans[1].title} Plan`}
-    continueButtonText="Continue with Cancellation"
-    goBackButtonText="Wait, Go Back"
-    confirmButtonText="Yes, Cancel My Subscription"
-    onCancel={async (planId) => {
-        console.log('cancel subscription', planId);
-        return new Promise((resolve) => {
-            setTimeout(() => {
-                resolve(void 0);
-            }, 2000); 
-        });
-    }}
-    onKeepSubscription={async (planId) => {
-        console.log('keep subscription', planId);
-        return new Promise((resolve) => {
-            setTimeout(() => {
-                resolve(void 0);
-            }, 1000);
-        });
-    }}
-    className="max-w-4xl"
-/>
+        <div className="flex flex-1 flex-col justify-center items-center p-4 min-h-[400px]">
+            <CancelSubscriptionCardTwo
+                title="We're sorry to see you go..."
+                description={`Before you cancel, we hope you'll consider upgrading to a ${plans[1].title} plan again.`}
+                plan={plans[1]}
+                warningText="If you cancel your subscription, you will lose access to your account and all your data will be deleted."
+                supportText="Need help? Our team is here to assist you."
+                supportLink="https://google.com/"
+                finalTitle="Final Step - Confirm Cancellation"
+                finalSubtitle="You'll lose access to all Pro features and your data will be permanently deleted after 30 days."
+                keepButtonText={`Keep My ${plans[1].title} Plan`}
+                continueButtonText="Continue with Cancellation"
+                goBackButtonText="Wait, Go Back"
+                confirmButtonText="Yes, Cancel My Subscription"
+                onCancel={async (planId) => {
+                    console.log('cancel subscription', planId);
+                    return new Promise((resolve) => {
+                        setTimeout(() => {
+                            resolve(void 0);
+                        }, 2000); 
+                    });
+                }}
+                onKeepSubscription={async (planId) => {
+                    console.log('keep subscription', planId);
+                    return new Promise((resolve) => {
+                        setTimeout(() => {
+                            resolve(void 0);
+                        }, 1000);
+                    });
+                }}
+            />
         </div>
     )
 }

--- a/src/registry/billingsdk/cancel-subscription-card-two.tsx
+++ b/src/registry/billingsdk/cancel-subscription-card-two.tsx
@@ -3,10 +3,10 @@
 import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
-import { Card, CardContent } from "@/components/ui/card"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { type Plan } from "@/lib/billingsdk-config";
 import { cn } from "@/lib/utils";
-import { ArrowRight, ChevronDown, Info,  Zap } from "lucide-react";
+import { ArrowRight, ChevronDown, Circle, Info, Zap } from "lucide-react";
 import { BiSupport } from "react-icons/bi";
 
 export interface CancelSubscriptionCardTwoProps {
@@ -88,161 +88,121 @@ export function CancelSubscriptionCardTwo({
     };
 
     return (
-        <Card className={cn(" sm:max-w-[500px] flex flex-col md:flex-row overflow-hidden w-full", className)}>
-            <CardContent className={cn("px-4 flex flex-col gap-4 w-full")}>
-                {!showFinalConfirmation &&(
-                    <>
-                      <div className="flex justify-end">
-                    <span className="text-destructive">Cancel Plan</span>
-                </div>
-                
-                <div className="flex flex-col gap-2 text-center md:text-left pl-4">
-                    <h2 className="text-lg sm:text-2xl font-semibold">{title}</h2>
-                    <p className="md:text-sm text-xs text-muted-foreground">{description}</p>
-                </div>
-                    </>
-                )}
+        <Card className={cn("max-w-2xl mx-auto w-full", className)}>
+            <CardHeader className="space-y-4">
+                <CardTitle className="text-lg sm:text-xl">{title}</CardTitle>
+                <p className="text-sm text-muted-foreground">{description}</p>
                 {error && (
                     <div className="p-3 bg-destructive/10 border border-destructive/20 rounded-md">
-                    <p className="text-sm text-destructive">{error}</p>
-                </div>
+                        <p className="text-sm text-destructive">{error}</p>
+                    </div>
                 )}
+            </CardHeader>
+            <CardContent className="space-y-6">
               
                 {/* Subscription Details */}
                 {!showFinalConfirmation && (
                     <div className="flex flex-col gap-4 p-4 bg-muted/50 rounded-lg">
                         <div className="flex items-center justify-between">
-                           <div className="flex text-left">
-                            <p className=" text-sm sm:text-lg ">
-                                Current Subscription:
-                            </p>
-                           </div>
-                           <div className="flex flex-col gap-1">
-                            <p className="font-semibold text-sm sm:text-lg">{plan.title} Plan </p>
+                            <div className="flex flex-col gap-1">
+                                <span className="font-semibold text-lg">{plan.title} Plan</span>
+                                <span className="text-sm text-muted-foreground">Current subscription</span>
+                            </div>
                             <Badge variant="secondary">
                                 {parseFloat(plan.monthlyPrice) >= 0 ? `${plan.currency}${plan.monthlyPrice}/monthly` : `${plan.monthlyPrice}/monthly`}
                             </Badge>
-                           </div>
                         </div>
                         <div className="flex flex-col gap-2">
-                            {/* Features */}
                             <Button 
                                 variant="ghost"
-                                className="flex justify-between items-center text-sm font-medium cursor-pointer transition-colors"
+                                className="w-full justify-between p-0 h-auto font-medium text-sm hover:bg-transparent"
                                 onClick={() => setShowBenefits(!showBenefits)}
                             >
-                                <span>Your Current Plan Benefits:</span>
+                                <span>Your Current Plan Benefits</span>
                                 <ChevronDown className={cn("w-4 h-4 transition-transform", showBenefits && "rotate-180")} />
                             </Button>
                             {showBenefits && (
-                                <>
+                                <div className="space-y-2 pl-2">
                                     {plan.features.slice(0, 4).map((feature, index) => (
-                                        <div key={index} className="flex items-center gap-2 pl-3">
-                                            <Zap className="w-4 h-4 fill-primary text-primary" />
+                                        <div key={index} className="flex items-center gap-2">
+                                            <Circle className="w-2 h-2 fill-primary text-primary" />
                                             <span className="text-sm text-muted-foreground">{feature.name}</span>
                                         </div>
                                     ))}
-                                </>
-                               
+                                </div>
                             )}
-                               <div className="mt-5 border-t border-border pt-5">
-                                {supportText && (
-                                <div className="flex justify-end ">
-                                    <p className="text-sm text-muted-foreground ">
-                                        {supportText}
-                                    </p>
-                                </div>
-                                )}
-                                {supportLink && (
-                                <div className="flex items-center gap-2 justify-end pt-5 ">
-                                <BiSupport className="w-4 h-4"/>
-                                    <a 
-                                    href={supportLink?.toString()}
-                                    className="text-xs sm:text-sm text-muted-foreground hover:text-primary transition-colors">
-                                       Contact Support
-                                    </a>   
-                                </div>
-                                )}
-                               
-                                  
-                                </div>
                         </div>
                     </div>
                 )}
-              
+
+                {/* Support Section */}
+                {!showFinalConfirmation && (supportText || supportLink) && (
+                    <div className="rounded-lg border p-4 bg-muted/10">
+                        {supportText && (
+                            <p className="text-sm text-muted-foreground mb-3">{supportText}</p>
+                        )}
+                        {supportLink && (
+                            <div className="flex items-center gap-2">
+                                <BiSupport className="w-4 h-4 text-muted-foreground" />
+                                <a 
+                                    href={supportLink}
+                                    className="text-sm text-muted-foreground hover:text-primary transition-colors"
+                                >
+                                    Contact Support
+                                </a>
+                            </div>
+                        )}
+                    </div>
+                )}
 
                 {!showFinalConfirmation ? (
-                    <div className="flex flex-col sm:flex-row gap-3 mt-auto">
+                    <div className="flex flex-col sm:flex-row gap-3">
                         <Button
                             className="flex-1"
                             onClick={handleKeepSubscription}
                             disabled={isLoading}
                         >
-                             {isLoading ? "Processing..." : (keepButtonText || "Keep My Subscription")}
+                            {isLoading ? "Processing..." : (keepButtonText || "Keep My Subscription")}
                         </Button>
                         <Button
-                            variant="ghost"
+                            variant="destructive"
                             className="flex-1"
                             onClick={handleContinueCancellation}
                             disabled={isLoading}
                         >
-                          {continueButtonText || "Continue Cancellation"}
+                            {continueButtonText || "Continue Cancellation"}
                         </Button>
                     </div>
                 ) : (
-                    <div className="flex flex-col gap-4 ">
-                        <div className="p-1  rounded-lg">
-                            <div className="border-b">
-                                  <h4 className="font-semibold text-lg sm:text-xl mb-2 text-foreground text-center">
-                                {finalTitle || "You are about to cancel your subscription"}
-                            </h4>
-                            <p className="text-xs sm:text-sm text-muted-foreground mb-4 text-center">
+                    <div className="flex flex-col gap-4">
+                        <div className="text-center p-4 bg-muted/50 rounded-lg">
+                            <h3 className="font-semibold mb-2 text-foreground">
+                                {finalTitle || "Final Step - Confirm Cancellation"}
+                            </h3>
+                            <p className="text-sm text-muted-foreground mb-2">
                                 {finalSubtitle || "You'll lose access to all Pro features and your data will be permanently deleted after 30 days."}
                             </p>
-                            </div>
-                          {/* Features */}
-                            <div className="flex flex-col gap-2 sm:ml-6 py-4">
-                                <p className="text-base font-medium text-foreground py-2.5">
-                                 Keep your plan to continue enjoying these benefits:
-                                </p>
-                             {plan.features.slice(0, 4).map((feature, index) => (
-                                        <div key={index} className="flex items-center gap-2 pl-3">
-                                            <Zap className="w-4 h-4 fill-primary text-primary" />
-                                            <p className="text-sm text-muted-foreground">{feature.name}</p>
-                                        </div>
-                                    ))}
-                                </div>
-                                  <div className="flex items-start mt-6 p-2 bg-destructive/10 border border-red-400/20 rounded-lg gap-3">
-                                    <Info className="w-4 h-4 text-destructive mt-1 flex-shrink-0" />
-                                    <p className="text-sm text-destructive ">
-                                      {warningText || "This action will immediately cancel your subscription."}  
-                                    </p>
-                                </div>
+                            <p className="text-sm text-destructive">
+                                {warningText || "This action cannot be undone and you'll lose access to all premium features."}
+                            </p>
                         </div>
-
-                        <div className="flex flex-col gap-3">
+                        <div className="flex flex-col sm:flex-row gap-3">
                             <Button
-                                className="w-full"
+                                variant="outline"
+                                className="flex-1"
                                 onClick={handleBack}
                                 disabled={isLoading}
                             >
-                                {goBackButtonText || "Never mind"}
+                                {goBackButtonText || "Go Back"}
                             </Button>
-
-                            <div className="flex justify-center">
-                                  <Button
-                                variant="ghost"
+                            <Button
+                                variant="destructive"
+                                className="flex-1"
                                 onClick={handleConfirmCancellation}
                                 disabled={isLoading}
-                                className="w-fit text-muted-foreground hover:text-destructive"
                             >
-                                <span className="flex items-center gap-2">
-                                    {isLoading ? "Cancelling..." : (confirmButtonText || "Cancel My Subscription")}
-                                    {!isLoading && <ArrowRight className="w-3 h-3 mt-1" />}
-                                </span>
+                                {isLoading ? "Cancelling..." : (confirmButtonText || "Yes, Cancel Subscription")}
                             </Button>
-                            </div>
-                          
                         </div>
                     </div>
                 )}


### PR DESCRIPTION
### Component
- **Cancel Subscription Card Two**

### Changes
- Replace custom structure with standard CardHeader + CardContent pattern
- Remove awkward red 'Cancel Plan' text from header
- Update 'Continue Cancellation' button to use destructive variant
- Improve collapsible benefits section styling
- Enhance support section layout and alignment
- Use consistent Circle icons for feature list
- Improve responsive design and visual hierarchy

### Summary
refer #211 

### Screenshots/Recordings (if UI)
| Before | After |
|--------|-------|
| <img width="300" src="https://github.com/user-attachments/assets/abf6fece-789c-4b9f-a4a0-6001a726b098" /> | <img width="300" src="https://github.com/user-attachments/assets/19e0c801-bbd7-4ddc-bf30-4bba9488358b" /> |

