### PR TITLE
Fix/coupon UI improvements

### DIFF
--- a/src/components/cancel-subscription-card-two-demo.tsx
+++ b/src/components/cancel-subscription-card-two-demo.tsx
@@ -6,38 +6,37 @@ import { plans } from "@/lib/billingsdk-config";
 
 export function CancelSubscriptionCardTwoDemo() {
     return(
-    <div className="flex flex-1 flex-col justify-center text-center p-2 min-h-[200px]">
-    <CancelSubscriptionCardTwo
-    title="We're sorry to see you go..."
-    description={`Before you cancel, we hope you'll consider upgrading to a ${plans[1].title} plan again.`}
-    plan={plans[1]}
-    warningText="If you cancel your subscription, you will lose access to your account and all your data will be deleted."
-    supportText="Need help? Our team is here to assist you."
-    supportLink="https://google.com/"
-    finalTitle="Final Step - Confirm Cancellation"
-    finalSubtitle="You'll lose access to all Pro features and your data will be permanently deleted after 30 days."
-    keepButtonText={`Keep My ${plans[1].title} Plan`}
-    continueButtonText="Continue with Cancellation"
-    goBackButtonText="Wait, Go Back"
-    confirmButtonText="Yes, Cancel My Subscription"
-    onCancel={async (planId) => {
-        console.log('cancel subscription', planId);
-        return new Promise((resolve) => {
-            setTimeout(() => {
-                resolve(void 0);
-            }, 2000); 
-        });
-    }}
-    onKeepSubscription={async (planId) => {
-        console.log('keep subscription', planId);
-        return new Promise((resolve) => {
-            setTimeout(() => {
-                resolve(void 0);
-            }, 1000);
-        });
-    }}
-    className="max-w-4xl"
-/>
+        <div className="flex flex-1 flex-col justify-center items-center p-4 min-h-[400px]">
+            <CancelSubscriptionCardTwo
+                title="We're sorry to see you go..."
+                description={`Before you cancel, we hope you'll consider upgrading to a ${plans[1].title} plan again.`}
+                plan={plans[1]}
+                warningText="If you cancel your subscription, you will lose access to your account and all your data will be deleted."
+                supportText="Need help? Our team is here to assist you."
+                supportLink="https://google.com/"
+                finalTitle="Final Step - Confirm Cancellation"
+                finalSubtitle="You'll lose access to all Pro features and your data will be permanently deleted after 30 days."
+                keepButtonText={`Keep My ${plans[1].title} Plan`}
+                continueButtonText="Continue with Cancellation"
+                goBackButtonText="Wait, Go Back"
+                confirmButtonText="Yes, Cancel My Subscription"
+                onCancel={async (planId) => {
+                    console.log('cancel subscription', planId);
+                    return new Promise((resolve) => {
+                        setTimeout(() => {
+                            resolve(void 0);
+                        }, 2000); 
+                    });
+                }}
+                onKeepSubscription={async (planId) => {
+                    console.log('keep subscription', planId);
+                    return new Promise((resolve) => {
+                        setTimeout(() => {
+                            resolve(void 0);
+                        }, 1000);
+                    });
+                }}
+            />
         </div>
     )
 }

--- a/src/components/coupon-demo.tsx
+++ b/src/components/coupon-demo.tsx
@@ -32,7 +32,7 @@ export function CouponDemo() {
   }
 
   return (
-    <div className="w-full flex justify-center items-center p-4 bg-background">
+    <div className="w-full flex justify-center items-center p-4 min-h-[400px]">
       <CouponGenerator
         companyName="Dodopayments"
         applicableOptions={[

--- a/src/registry/billingsdk/cancel-subscription-card-two.tsx
+++ b/src/registry/billingsdk/cancel-subscription-card-two.tsx
@@ -6,7 +6,7 @@ import { Badge } from "@/components/ui/badge"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { type Plan } from "@/lib/billingsdk-config";
 import { cn } from "@/lib/utils";
-import { ArrowRight, ChevronDown, Circle, Info, Zap } from "lucide-react";
+import { ChevronDown, Circle } from "lucide-react";
 import { BiSupport } from "react-icons/bi";
 
 export interface CancelSubscriptionCardTwoProps {

--- a/src/registry/billingsdk/cancel-subscription-card-two.tsx
+++ b/src/registry/billingsdk/cancel-subscription-card-two.tsx
@@ -3,10 +3,10 @@
 import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
-import { Card, CardContent } from "@/components/ui/card"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { type Plan } from "@/lib/billingsdk-config";
 import { cn } from "@/lib/utils";
-import { ArrowRight, ChevronDown, Info,  Zap } from "lucide-react";
+import { ArrowRight, ChevronDown, Circle, Info, Zap } from "lucide-react";
 import { BiSupport } from "react-icons/bi";
 
 export interface CancelSubscriptionCardTwoProps {
@@ -88,161 +88,121 @@ export function CancelSubscriptionCardTwo({
     };
 
     return (
-        <Card className={cn(" sm:max-w-[500px] flex flex-col md:flex-row overflow-hidden w-full", className)}>
-            <CardContent className={cn("px-4 flex flex-col gap-4 w-full")}>
-                {!showFinalConfirmation &&(
-                    <>
-                      <div className="flex justify-end">
-                    <span className="text-destructive">Cancel Plan</span>
-                </div>
-                
-                <div className="flex flex-col gap-2 text-center md:text-left pl-4">
-                    <h2 className="text-lg sm:text-2xl font-semibold">{title}</h2>
-                    <p className="md:text-sm text-xs text-muted-foreground">{description}</p>
-                </div>
-                    </>
-                )}
+        <Card className={cn("max-w-2xl mx-auto w-full", className)}>
+            <CardHeader className="space-y-4">
+                <CardTitle className="text-lg sm:text-xl">{title}</CardTitle>
+                <p className="text-sm text-muted-foreground">{description}</p>
                 {error && (
                     <div className="p-3 bg-destructive/10 border border-destructive/20 rounded-md">
-                    <p className="text-sm text-destructive">{error}</p>
-                </div>
+                        <p className="text-sm text-destructive">{error}</p>
+                    </div>
                 )}
+            </CardHeader>
+            <CardContent className="space-y-6">
               
                 {/* Subscription Details */}
                 {!showFinalConfirmation && (
                     <div className="flex flex-col gap-4 p-4 bg-muted/50 rounded-lg">
                         <div className="flex items-center justify-between">
-                           <div className="flex text-left">
-                            <p className=" text-sm sm:text-lg ">
-                                Current Subscription:
-                            </p>
-                           </div>
-                           <div className="flex flex-col gap-1">
-                            <p className="font-semibold text-sm sm:text-lg">{plan.title} Plan </p>
+                            <div className="flex flex-col gap-1">
+                                <span className="font-semibold text-lg">{plan.title} Plan</span>
+                                <span className="text-sm text-muted-foreground">Current subscription</span>
+                            </div>
                             <Badge variant="secondary">
                                 {parseFloat(plan.monthlyPrice) >= 0 ? `${plan.currency}${plan.monthlyPrice}/monthly` : `${plan.monthlyPrice}/monthly`}
                             </Badge>
-                           </div>
                         </div>
                         <div className="flex flex-col gap-2">
-                            {/* Features */}
                             <Button 
                                 variant="ghost"
-                                className="flex justify-between items-center text-sm font-medium cursor-pointer transition-colors"
+                                className="w-full justify-between p-0 h-auto font-medium text-sm hover:bg-transparent"
                                 onClick={() => setShowBenefits(!showBenefits)}
                             >
-                                <span>Your Current Plan Benefits:</span>
+                                <span>Your Current Plan Benefits</span>
                                 <ChevronDown className={cn("w-4 h-4 transition-transform", showBenefits && "rotate-180")} />
                             </Button>
                             {showBenefits && (
-                                <>
+                                <div className="space-y-2 pl-2">
                                     {plan.features.slice(0, 4).map((feature, index) => (
-                                        <div key={index} className="flex items-center gap-2 pl-3">
-                                            <Zap className="w-4 h-4 fill-primary text-primary" />
+                                        <div key={index} className="flex items-center gap-2">
+                                            <Circle className="w-2 h-2 fill-primary text-primary" />
                                             <span className="text-sm text-muted-foreground">{feature.name}</span>
                                         </div>
                                     ))}
-                                </>
-                               
+                                </div>
                             )}
-                               <div className="mt-5 border-t border-border pt-5">
-                                {supportText && (
-                                <div className="flex justify-end ">
-                                    <p className="text-sm text-muted-foreground ">
-                                        {supportText}
-                                    </p>
-                                </div>
-                                )}
-                                {supportLink && (
-                                <div className="flex items-center gap-2 justify-end pt-5 ">
-                                <BiSupport className="w-4 h-4"/>
-                                    <a 
-                                    href={supportLink?.toString()}
-                                    className="text-xs sm:text-sm text-muted-foreground hover:text-primary transition-colors">
-                                       Contact Support
-                                    </a>   
-                                </div>
-                                )}
-                               
-                                  
-                                </div>
                         </div>
                     </div>
                 )}
-              
+
+                {/* Support Section */}
+                {!showFinalConfirmation && (supportText || supportLink) && (
+                    <div className="rounded-lg border p-4 bg-muted/10">
+                        {supportText && (
+                            <p className="text-sm text-muted-foreground mb-3">{supportText}</p>
+                        )}
+                        {supportLink && (
+                            <div className="flex items-center gap-2">
+                                <BiSupport className="w-4 h-4 text-muted-foreground" />
+                                <a 
+                                    href={supportLink}
+                                    className="text-sm text-muted-foreground hover:text-primary transition-colors"
+                                >
+                                    Contact Support
+                                </a>
+                            </div>
+                        )}
+                    </div>
+                )}
 
                 {!showFinalConfirmation ? (
-                    <div className="flex flex-col sm:flex-row gap-3 mt-auto">
+                    <div className="flex flex-col sm:flex-row gap-3">
                         <Button
                             className="flex-1"
                             onClick={handleKeepSubscription}
                             disabled={isLoading}
                         >
-                             {isLoading ? "Processing..." : (keepButtonText || "Keep My Subscription")}
+                            {isLoading ? "Processing..." : (keepButtonText || "Keep My Subscription")}
                         </Button>
                         <Button
-                            variant="ghost"
+                            variant="destructive"
                             className="flex-1"
                             onClick={handleContinueCancellation}
                             disabled={isLoading}
                         >
-                          {continueButtonText || "Continue Cancellation"}
+                            {continueButtonText || "Continue Cancellation"}
                         </Button>
                     </div>
                 ) : (
-                    <div className="flex flex-col gap-4 ">
-                        <div className="p-1  rounded-lg">
-                            <div className="border-b">
-                                  <h4 className="font-semibold text-lg sm:text-xl mb-2 text-foreground text-center">
-                                {finalTitle || "You are about to cancel your subscription"}
-                            </h4>
-                            <p className="text-xs sm:text-sm text-muted-foreground mb-4 text-center">
+                    <div className="flex flex-col gap-4">
+                        <div className="text-center p-4 bg-muted/50 rounded-lg">
+                            <h3 className="font-semibold mb-2 text-foreground">
+                                {finalTitle || "Final Step - Confirm Cancellation"}
+                            </h3>
+                            <p className="text-sm text-muted-foreground mb-2">
                                 {finalSubtitle || "You'll lose access to all Pro features and your data will be permanently deleted after 30 days."}
                             </p>
-                            </div>
-                          {/* Features */}
-                            <div className="flex flex-col gap-2 sm:ml-6 py-4">
-                                <p className="text-base font-medium text-foreground py-2.5">
-                                 Keep your plan to continue enjoying these benefits:
-                                </p>
-                             {plan.features.slice(0, 4).map((feature, index) => (
-                                        <div key={index} className="flex items-center gap-2 pl-3">
-                                            <Zap className="w-4 h-4 fill-primary text-primary" />
-                                            <p className="text-sm text-muted-foreground">{feature.name}</p>
-                                        </div>
-                                    ))}
-                                </div>
-                                  <div className="flex items-start mt-6 p-2 bg-destructive/10 border border-red-400/20 rounded-lg gap-3">
-                                    <Info className="w-4 h-4 text-destructive mt-1 flex-shrink-0" />
-                                    <p className="text-sm text-destructive ">
-                                      {warningText || "This action will immediately cancel your subscription."}  
-                                    </p>
-                                </div>
+                            <p className="text-sm text-destructive">
+                                {warningText || "This action cannot be undone and you'll lose access to all premium features."}
+                            </p>
                         </div>
-
-                        <div className="flex flex-col gap-3">
+                        <div className="flex flex-col sm:flex-row gap-3">
                             <Button
-                                className="w-full"
+                                variant="outline"
+                                className="flex-1"
                                 onClick={handleBack}
                                 disabled={isLoading}
                             >
-                                {goBackButtonText || "Never mind"}
+                                {goBackButtonText || "Go Back"}
                             </Button>
-
-                            <div className="flex justify-center">
-                                  <Button
-                                variant="ghost"
+                            <Button
+                                variant="destructive"
+                                className="flex-1"
                                 onClick={handleConfirmCancellation}
                                 disabled={isLoading}
-                                className="w-fit text-muted-foreground hover:text-destructive"
                             >
-                                <span className="flex items-center gap-2">
-                                    {isLoading ? "Cancelling..." : (confirmButtonText || "Cancel My Subscription")}
-                                    {!isLoading && <ArrowRight className="w-3 h-3 mt-1" />}
-                                </span>
+                                {isLoading ? "Cancelling..." : (confirmButtonText || "Yes, Cancel Subscription")}
                             </Button>
-                            </div>
-                          
                         </div>
                     </div>
                 )}

--- a/src/registry/billingsdk/coupon.tsx
+++ b/src/registry/billingsdk/coupon.tsx
@@ -7,6 +7,7 @@ import { Input } from "@/components/ui/input"
 import { Switch } from "@/components/ui/switch"
 import { Label } from "@/components/ui/label"
 import { Copy, ArrowLeft, Share2, Scissors } from "lucide-react"
+import { cn } from "@/lib/utils"
 import {
     Select,
     SelectContent,
@@ -151,95 +152,80 @@ export function CouponGenerator({
     return (
         <>
             {generated ? (
-                <Card
-                    className={`w-full max-w-md animate-in fade-in-0 slide-in-from-bottom-4 duration-700 
-                    bg-background text-foreground
-                    border border-border shadow-2xl 
-                    ${cardClassName || ""}`}
-                >
+                <Card className={cn("w-full max-w-md mx-auto", cardClassName)}>
                     <CardContent className="p-0">
                         <div className="relative overflow-hidden">
-                            <div className="bg-zinc-900 dark:bg-zinc-100 p-6 relative">
-                                <div className="absolute top-0 left-0 w-full h-full opacity-5">
+                            <div className="bg-primary p-8 relative">
+                                <div className="absolute top-0 left-0 w-full h-full opacity-10">
                                     <div className="w-full h-full bg-[repeating-linear-gradient(45deg,transparent,transparent_10px,rgba(255,255,255,0.1)_10px,rgba(255,255,255,0.1)_20px)]"></div>
                                 </div>
-                                <div className="relative z-10 text-center">
-                                    <div className="inline-flex items-center gap-2 mb-2">
-                                        <Scissors className="w-4 h-4 text-white dark:text-zinc-900" />
-                                        <span className="text-xs font-medium text-zinc-400 dark:text-zinc-600 uppercase tracking-wider">
+                                <div className="relative z-10 text-center space-y-3">
+                                    <div className="inline-flex items-center gap-2">
+                                        <Scissors className="w-4 h-4 text-primary-foreground" />
+                                        <span className="text-xs font-medium text-primary-foreground/80 uppercase tracking-wider">
                                             Coupon
                                         </span>
                                     </div>
-                                    <div className="text-3xl font-bold text-white dark:text-zinc-900 tracking-tight mb-1">
+                                    <div className="text-3xl font-bold text-primary-foreground tracking-tight">
                                         {generatedCouponCode}
                                     </div>
-                                    <div className="text-sm text-zinc-300 dark:text-zinc-700 font-medium">{companyName}</div>
+                                    <div className="text-sm text-primary-foreground/80 font-medium">{companyName}</div>
                                 </div>
                             </div>
 
-                            <div className="p-6 bg-white dark:bg-zinc-900">
-                                <div className="text-center space-y-2">
-                                    <div className="text-2xl font-bold text-zinc-900 dark:text-white">{discount}% OFF</div>
-                                    <div className="text-sm text-zinc-600 dark:text-zinc-400">
+                            <div className="p-8 bg-card">
+                                <div className="text-center space-y-3">
+                                    <div className="text-2xl font-bold text-card-foreground">{discount}% OFF</div>
+                                    <div className="text-sm text-muted-foreground">
                                         Valid until {endDate}
                                     </div>
                                 </div>
                             </div>
 
-                            <div className="absolute left-0 top-1/2 transform -translate-y-1/2 w-6 h-6 bg-zinc-50 dark:bg-zinc-950 rounded-full -ml-3 border-2 border-zinc-200 dark:border-zinc-800"></div>
-                            <div className="absolute right-0 top-1/2 transform -translate-y-1/2 w-6 h-6 bg-zinc-50 dark:bg-zinc-950 rounded-full -mr-3 border-2 border-zinc-200 dark:border-zinc-800"></div>
+                            <div className="absolute left-0 top-1/2 transform -translate-y-1/2 w-6 h-6 bg-background rounded-full -ml-3 border-2 border-border"></div>
+                            <div className="absolute right-0 top-1/2 transform -translate-y-1/2 w-6 h-6 bg-background rounded-full -mr-3 border-2 border-border"></div>
                         </div>
                     </CardContent>
 
-                    <CardFooter className="flex justify-between items-center p-4 border-t border-border">
+                    <CardFooter className="flex justify-between items-center p-6 border-t">
                         <Button
                             variant="ghost"
                             size="sm"
                             onClick={() => setGenerated(false)}
-                            className="text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
                         >
-                            <ArrowLeft className="w-4 h-4 mr-1" />
+                            <ArrowLeft className="w-4 h-4 mr-2" />
                             Back
                         </Button>
-                        <div className="flex gap-2">
+                        <div className="flex gap-3">
                             <Button
                                 variant="outline"
                                 size="sm"
                                 onClick={() => onCopy?.(generatedCouponCode)}
-                                className="border-border hover:bg-muted transition-colors bg-transparent"
                             >
-                                <Copy className="w-4 h-4 mr-1" />
+                                <Copy className="w-4 h-4 mr-2" />
                                 Copy
                             </Button>
                             <Button
                                 variant="outline"
                                 size="sm"
                                 onClick={() => onShare?.(generatedCouponCode)}
-                                className="border-border hover:bg-muted transition-colors bg-transparent"
                             >
-                                <Share2 className="w-4 h-4 mr-1" />
+                                <Share2 className="w-4 h-4 mr-2" />
                                 Share
                             </Button>
                         </div>
                     </CardFooter>
                 </Card>
             ) : (
-                <Card
-                    className={`w-full max-w-md animate-in fade-in-0 slide-in-from-bottom-4 duration-700 
-                    bg-background text-foreground
-                    border border-border shadow-2xl 
-                    ${cardClassName || ""}`}
-                >
-                    <CardHeader className="pb-4">
-                        <CardTitle className="text-xl font-semibold text-center">
+                <Card className={cn("w-full max-w-md mx-auto", cardClassName)}>
+                    <CardHeader className="space-y-4">
+                        <CardTitle className="text-lg sm:text-xl text-center">
                             Create Coupon Code
                         </CardTitle>
                     </CardHeader>
 
-                    <div className="h-px bg-border mx-6"></div>
-
-                    <CardContent className="space-y-6 p-6">
-                        <div className="grid grid-cols-2 gap-4">
+                    <CardContent className="space-y-6">
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                             <div className="space-y-2">
                                 <Label htmlFor="discount" className="text-sm font-medium">
                                     Discount (%)
@@ -251,19 +237,18 @@ export function CouponGenerator({
                                     onChange={handleDiscountChange}
                                     min={0}
                                     max={100}
-                                    className="bg-background border-border text-foreground"
                                 />
                                 {discountError && (
-                                    <div className="text-sm text-red-500">{discountError}</div>
+                                    <p className="text-sm text-destructive">{discountError}</p>
                                 )}
                             </div>
 
                             <div className="space-y-2">
                                 <Label htmlFor="applicable" className="text-sm font-medium">
-                                    Applicable to <span className="text-red-500">*</span>
+                                    Applicable to <span className="text-destructive">*</span>
                                 </Label>
                                 <Select value={selectedRule} onValueChange={setSelectedRule}>
-                                    <SelectTrigger className="bg-background border-border text-foreground">
+                                    <SelectTrigger>
                                         <SelectValue placeholder="Select rule" />
                                     </SelectTrigger>
                                     <SelectContent>
@@ -273,7 +258,6 @@ export function CouponGenerator({
                                                 <SelectItem
                                                     key={option.value}
                                                     value={option.value}
-                                                    className="text-foreground hover:bg-muted"
                                                 >
                                                     {option.label}
                                                 </SelectItem>
@@ -284,13 +268,13 @@ export function CouponGenerator({
                             </div>
                         </div>
 
-                        <div className="space-y-3">
+                        <div className="space-y-4">
                             <Label className="text-sm font-medium">
-                                Validity Period <span className="text-red-500">*</span>
+                                Validity Period <span className="text-destructive">*</span>
                             </Label>
-                            <div className="grid grid-cols-2 gap-3">
+                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                                 <div className="space-y-2">
-                                    <Label htmlFor="start-date" className="text-xs">
+                                    <Label htmlFor="start-date" className="text-sm">
                                         Start Date
                                     </Label>
                                     <Input
@@ -298,11 +282,10 @@ export function CouponGenerator({
                                         id="start-date"
                                         value={startDate}
                                         onChange={(e) => setStartDate(e.target.value)}
-                                        className="bg-background border-border text-foreground"
                                     />
                                 </div>
                                 <div className="space-y-2">
-                                    <Label htmlFor="end-date" className="text-xs">
+                                    <Label htmlFor="end-date" className="text-sm">
                                         End Date
                                     </Label>
                                     <Input
@@ -310,22 +293,20 @@ export function CouponGenerator({
                                         id="end-date"
                                         value={endDate}
                                         onChange={(e) => setEndDate(e.target.value)}
-                                        className="bg-background border-border text-foreground"
                                     />
                                 </div>
                             </div>
                             {dateError && (
-                                <div className="text-sm text-red-500 mt-2">{dateError}</div>
+                                <p className="text-sm text-destructive">{dateError}</p>
                             )}
                         </div>
 
-                        <div className="space-y-3">
+                        <div className="space-y-4">
                             <div className="flex items-center space-x-3">
                                 <Switch
                                     id="custom-code"
                                     checked={enabled}
                                     onCheckedChange={setEnabled}
-                                    className="data-[state=checked]:bg-zinc-900 data-[state=unchecked]:bg-zinc-200 dark:data-[state=checked]:bg-zinc-100 dark:data-[state=unchecked]:bg-zinc-700"
                                 />
                                 <Label htmlFor="custom-code" className="text-sm font-medium">
                                     Custom Code
@@ -333,7 +314,6 @@ export function CouponGenerator({
                             </div>
                             {enabled && (
                                 <Input
-                                    className="bg-background border-border text-foreground"
                                     placeholder="DODO20"
                                     value={customCode}
                                     onChange={(e) => setCustomCode(e.target.value)}
@@ -342,11 +322,11 @@ export function CouponGenerator({
                         </div>
                     </CardContent>
 
-                    <CardFooter className="flex justify-end p-6 pt-0">
+                    <CardFooter className="flex justify-end p-6">
                         <Button
                             onClick={handleGenerate}
                             disabled={!isFormValid}
-                            className={`bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900 hover:bg-zinc-800 dark:hover:bg-zinc-200 transition-all duration-200 hover:scale-[1.02] shadow-lg disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100 disabled:bg-zinc-900 dark:disabled:bg-zinc-100 ${generateButtonClassName || ""}`}
+                            className={cn("w-full sm:w-auto", generateButtonClassName)}
                         >
                             Generate Coupon
                         </Button>


### PR DESCRIPTION
### Component
- **Coupon**

### Changes

- Replace custom zinc colors with design system tokens (primary, card-foreground, muted-foreground)
- Standardize `CardHeader` + `CardContent` + `CardFooter` structure with consistent spacing
- Improve form layout with better responsive grid (`grid-cols-1` `md:grid-cols-2`)
- Update error styling to use `text-destructive` instead of `text-red-500`
- Remove custom button styling and use standard variants (`ghost`, `outline`)
- Enhance spacing throughout: `p-6` to `p-8 for` coupon display, `gap-4` to `gap-6` for form grid
- Improve visual hierarchy with `space-y-3` and `space-y-4` for better section separation
- Ensure all imports are used and no lint errors remain

### Summary
refer #211 

### Screenshots/Recordings (if UI)
| Before | After |
|--------|-------|
| <img width="501" height="539" alt="image" src="https://github.com/user-attachments/assets/bd05d901-1eca-49b0-be42-215ea1d1f403" /> | <img width="492" height="482" alt="image" src="https://github.com/user-attachments/assets/76facdac-2ef8-405c-a302-fd3563ac259b" /> |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Support section to the cancellation flow with optional help text and a Contact Support link.
  - Introduced a clearer final confirmation step with updated button labels (Go Back and a destructive Cancel).

- UI/Style
  - Redesigned Cancel Subscription card: centered layout, updated headers, icons, spacing, and warning presentation.
  - Coupon generator restyled with a primary theme, cleaner card structure, refined footer buttons, and improved error messaging.
  - Form layout made more responsive and simplified.
  - Demo containers now center content with increased padding and a taller minimum height; background removed from coupon demo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->