### PR TITLE
CLI: Add flags, centralize framework/provider matrix, improve local testing, update docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,25 @@ Thank you for your interest in contributing. This document explains how to set u
 4. Consume in another project:
    - `npx shadcn@latest add http://localhost:3000/r/<component>.json`
 
+## CLI Local Development & Testing
+
+1. Build transport templates:
+   - `node packages/cli/dist/index.js build`
+   - Outputs `public/tr/*.json` from `packages/templates/registry.json`
+2. Point the CLI to local transports (same repo root):
+   - `BILLINGSDK_REGISTRY_BASE=file://$PWD/public/tr \
+      node packages/cli/dist/index.js init --framework express --provider dodopayments --yes --cwd /tmp/billingsdk-test`
+3. Flags supported by `init`:
+   - `--framework <nextjs|express|react|fastify|hono>`
+   - `--provider <dodopayments|stripe>` (Stripe valid for Express/Hono)
+   - `--yes` non-interactive
+   - `--no-install` skip dependency installation
+   - `--registry-base <url>` override transport base (env: `BILLINGSDK_REGISTRY_BASE`)
+   - `--cwd <path>` run against a different directory
+4. Quick smoke test script idea:
+   - `rm -rf /tmp/billingsdk-test && mkdir -p /tmp/billingsdk-test && npm init -y -w /tmp/billingsdk-test`
+   - Run the `init` command with `--yes` as above
+
 ## Development Guidelines
 
 - Use Tailwind utilities and existing theme tokens; avoid hard-coded color values.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,10 @@ Thank you for your interest in contributing. This document explains how to set u
 2. Point the CLI to local transports (same repo root):
    - `BILLINGSDK_REGISTRY_BASE=file://$PWD/public/tr \
       node packages/cli/dist/index.js init --framework express --provider dodopayments --yes --cwd /tmp/billingsdk-test`
+   - Alternatively, run the site on localhost and link the CLI:
+     - `npm run dev` (serves `http://localhost:3000/tr`)
+     - `cd packages/cli && npm run build && npm link`
+     - In another project: `BILLINGSDK_REGISTRY_BASE=http://localhost:3000/tr billingsdk init --framework express --provider dodopayments --yes`
 3. Flags supported by `init`:
    - `--framework <nextjs|express|react|fastify|hono>`
    - `--provider <dodopayments|stripe>` (Stripe valid for Express/Hono)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,10 @@ Thank you for your interest in contributing. This document explains how to set u
    - `--no-install` skip dependency installation
    - `--registry-base <url>` override transport base (env: `BILLINGSDK_REGISTRY_BASE`)
    - `--cwd <path>` run against a different directory
+   - `--force` overwrite files without prompt
+   - `--dry-run` print actions without writing files or installing
+   - `--verbose` show registry URL, placement, and actions
+   - `--package-manager <npm|pnpm|yarn|bun>` choose installer
 4. Quick smoke test script idea:
    - `rm -rf /tmp/billingsdk-test && mkdir -p /tmp/billingsdk-test && npm init -y -w /tmp/billingsdk-test`
    - Run the `init` command with `--yes` as above

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -42,6 +42,9 @@ BILLINGSDK_REGISTRY_BASE=file://$PWD/public/tr \
 
 # skip dependency installation
 npx @billingsdk/cli init --framework hono --provider stripe --yes --no-install
+
+# dry-run with verbose output and custom package manager
+npx @billingsdk/cli init --framework nextjs --provider dodopayments --yes --dry-run --verbose --package-manager pnpm
 ```
 
 Flags:
@@ -51,10 +54,10 @@ Flags:
 - `--no-install` skip dependency installation
 - `--registry-base <url>` override template base (env: `BILLINGSDK_REGISTRY_BASE`)
 - `--cwd <path>` operate in a different directory
- - `--force` overwrite files without prompt
- - `--dry-run` print actions without writing files or installing
- - `--verbose` show registry URL, placement, and actions
- - `--package-manager <npm|pnpm|yarn|bun>` choose installer
+- `--force` overwrite files without prompt
+- `--dry-run` print actions without writing files or installing
+- `--verbose` show registry URL, placement, and actions
+- `--package-manager <npm|pnpm|yarn|bun>` choose installer
 
 ### Add Components
 
@@ -223,9 +226,11 @@ npm run dev
 cd packages/cli && npm run build && npm link
 
 # 3) In another project, run the linked CLI
-#    (this will fetch from http://localhost:3000/tr if you temporarily change
-#     the default base in add-files.ts, or set BILLINGSDK_REGISTRY_BASE to localhost)
+#    (uses the globally linked "billingsdk" bin; without linking, use `npx @billingsdk/cli`)
+#    (fetches from http://localhost:3000/tr if you set BILLINGSDK_REGISTRY_BASE accordingly)
 BILLINGSDK_REGISTRY_BASE=http://localhost:3000/tr billingsdk init --framework express --provider dodopayments --yes
+# or:
+# BILLINGSDK_REGISTRY_BASE=http://localhost:3000/tr npx @billingsdk/cli init --framework express --provider dodopayments --yes
 ```
 ### Building the CLI
 
@@ -257,7 +262,7 @@ npx @billingsdk/cli --help
 chmod +x node_modules/.bin/@billingsdk/cli
 ```
 
-**Transport not found**
+#### Transport not found
 ```bash
 # Build transports locally, then point CLI at file:// registry
 node packages/cli/dist/index.js build

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -51,6 +51,10 @@ Flags:
 - `--no-install` skip dependency installation
 - `--registry-base <url>` override template base (env: `BILLINGSDK_REGISTRY_BASE`)
 - `--cwd <path>` operate in a different directory
+ - `--force` overwrite files without prompt
+ - `--dry-run` print actions without writing files or installing
+ - `--verbose` show registry URL, placement, and actions
+ - `--package-manager <npm|pnpm|yarn|bun>` choose installer
 
 ### Add Components
 
@@ -206,13 +210,6 @@ The CLI automatically detects your framework based on your project dependencies 
 ### Build transport templates (for local testing)
 
 ```bash
-# generate public/tr/*.json from packages/templates/registry.json
-npx tsx packages/cli/src/commands/build.ts
-```
-
-Or use the CLI command from the repo root:
-
-```bash
 node packages/cli/dist/index.js build
 ```
 
@@ -246,10 +243,11 @@ npx @billingsdk/cli --help
 chmod +x node_modules/.bin/@billingsdk/cli
 ```
 
-**Network issues**
+**Transport not found**
 ```bash
-# Check internet connection
-# CLI downloads templates from @billingsdk/cli.com
+# Build transports locally, then point CLI at file:// registry
+node packages/cli/dist/index.js build
+BILLINGSDK_REGISTRY_BASE=file://$PWD/public/tr node packages/cli/dist/index.js init --framework express --provider dodopayments --yes --cwd /tmp/app
 ```
 
 ### Getting Help

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -30,6 +30,28 @@ This interactive command will:
 - Install all necessary dependencies
 - Generate configuration files and boilerplate code
 
+### Non-interactive flags
+
+```bash
+# fully non-interactive
+npx @billingsdk/cli init --framework nextjs --provider dodopayments --yes
+
+# point to local built templates
+BILLINGSDK_REGISTRY_BASE=file://$PWD/public/tr \
+  npx @billingsdk/cli init --framework express --provider dodopayments --yes --cwd /tmp/my-app
+
+# skip dependency installation
+npx @billingsdk/cli init --framework hono --provider stripe --yes --no-install
+```
+
+Flags:
+- `--framework <nextjs|express|react|fastify|hono>`
+- `--provider <dodopayments|stripe>` (Stripe valid for Express/Hono)
+- `--yes` skip prompts
+- `--no-install` skip dependency installation
+- `--registry-base <url>` override template base (env: `BILLINGSDK_REGISTRY_BASE`)
+- `--cwd <path>` operate in a different directory
+
 ### Add Components
 
 ```bash
@@ -180,6 +202,19 @@ The CLI automatically detects your framework based on your project dependencies 
 - 🚧 **Additional providers** - Based on community demand
 
 ## Development
+
+### Build transport templates (for local testing)
+
+```bash
+# generate public/tr/*.json from packages/templates/registry.json
+npx tsx packages/cli/src/commands/build.ts
+```
+
+Or use the CLI command from the repo root:
+
+```bash
+node packages/cli/dist/index.js build
+```
 
 ### Building the CLI
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -213,6 +213,20 @@ The CLI automatically detects your framework based on your project dependencies 
 node packages/cli/dist/index.js build
 ```
 
+### Local linking workflow (optional)
+
+```bash
+# 1) Run the docs site locally (serves transports at http://localhost:3000/tr)
+npm run dev
+
+# 2) Link the CLI for development
+cd packages/cli && npm run build && npm link
+
+# 3) In another project, run the linked CLI
+#    (this will fetch from http://localhost:3000/tr if you temporarily change
+#     the default base in add-files.ts, or set BILLINGSDK_REGISTRY_BASE to localhost)
+BILLINGSDK_REGISTRY_BASE=http://localhost:3000/tr billingsdk init --framework express --provider dodopayments --yes
+```
 ### Building the CLI
 
 ```bash

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -14,6 +14,10 @@ export const initCommand = new Command()
   .option("--no-install")
   .option("--registry-base <url>")
   .option("--cwd <path>")
+  .option("--force")
+  .option("--dry-run")
+  .option("--verbose")
+  .option("--package-manager <pm>")
   .action(async (opts: any) => {
     try {
       intro("Welcome to Billing SDK Setup!");
@@ -85,7 +89,11 @@ export const initCommand = new Command()
         await addFiles(frameworkValue, providerValue, {
           registryBase: opts?.registryBase,
           cwd: opts?.cwd,
-          installDeps: opts?.noInstall ? false : true
+          installDeps: opts?.install === false ? false : true,
+          forceOverwrite: Boolean(opts?.force),
+          dryRun: Boolean(opts?.dryRun),
+          verbose: Boolean(opts?.verbose),
+          packageManager: opts?.packageManager
         });
         s.stop("Setup completed successfully!");
       } catch (error) {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -2,60 +2,91 @@ import { Command } from "commander";
 import { cancel, intro, isCancel, outro, select, spinner } from "@clack/prompts";
 import { addFiles } from "../scripts/add-files.js";
 import { detectFramework } from "../scripts/detect-framework.js";
+import { SupportedFramework, SupportedProvider, getAllowedProvidersForFramework, isValidCombination, supportedFrameworks } from "../config/matrix.js";
 
 export const initCommand = new Command()
   .name("init")
   .description("Initialize a new billing project")
   .summary("Set up billing components and framework integration")
-  .action(async () => {
+  .option("--framework <framework>")
+  .option("--provider <provider>")
+  .option("--yes")
+  .option("--no-install")
+  .option("--registry-base <url>")
+  .option("--cwd <path>")
+  .action(async (opts: any) => {
     try {
       intro("Welcome to Billing SDK Setup!");
 
       const detectedFramework = detectFramework();
-      const framework = await select({
-        message: "Which framework you are using? (Adding more frameworks soon)",
-        options: [
-          { value: "nextjs", label: detectedFramework === "nextjs" ? "Next.js (detected)" : "Next.js", hint: "React framework with App Router" },
-          { value: "express", label: detectedFramework === "express" ? "Express.js (detected)" : "Express.js", hint: "Node.js web framework" },
-          { value: "react", label: detectedFramework === "react" ? "React.js (detected)" : "React.js", hint: "Client-side React app template" },
-          { value: "hono", label: detectedFramework === "hono" ? "Hono.js (detected)" : "Hono.js", hint: "Lightweight web framework for edge runtimes" },
-          { value: "fastify", label: detectedFramework === "fastify" ? "Fastify.js (detected)" : "Fastify.js", hint: "Fast and low overhead web framework" }
-        ],
-        initialValue: detectedFramework ?? undefined  // cursor will already be on detected framework
-      });
 
-      if (isCancel(framework)) {
+      let frameworkValue: SupportedFramework | null = null;
+      let providerValue: SupportedProvider | null = null;
+
+      const flagFramework = opts?.framework as SupportedFramework | undefined;
+      const flagProvider = opts?.provider as SupportedProvider | undefined;
+      const nonInteractive = Boolean(opts?.yes);
+
+      if (flagFramework && supportedFrameworks.includes(flagFramework)) {
+        frameworkValue = flagFramework;
+      }
+
+      if (flagProvider === "dodopayments" || flagProvider === "stripe") {
+        providerValue = flagProvider;
+      }
+
+      if (nonInteractive && frameworkValue && providerValue) {
+        if (!isValidCombination(frameworkValue, providerValue)) {
+          cancel("Invalid framework/provider combination.");
+          process.exit(1);
+        }
+      } else {
+        if (!frameworkValue) {
+          const framework = await select({
+            message: "Which framework you are using? (Adding more frameworks soon)",
+            options: supportedFrameworks.map((fw) => ({
+              value: fw,
+              label:
+                detectedFramework === fw
+                  ? (fw === "nextjs" ? "Next.js (detected)" : fw === "express" ? "Express.js (detected)" : fw === "react" ? "React.js (detected)" : fw === "hono" ? "Hono.js (detected)" : "Fastify.js (detected)")
+                  : (fw === "nextjs" ? "Next.js" : fw === "express" ? "Express.js" : fw === "react" ? "React.js" : fw === "hono" ? "Hono.js" : "Fastify.js"),
+            })),
+            initialValue: detectedFramework ?? undefined
+          });
+          if (isCancel(framework)) {
+            cancel("Setup cancelled.");
+            process.exit(0);
+          }
+          frameworkValue = framework as SupportedFramework;
+        }
+
+        const allowedProviders = getAllowedProvidersForFramework(frameworkValue);
+        if (!providerValue) {
+          const providerChoice = await select({
+            message: "Which payment provider would you like to use? (Adding more providers soon)",
+            options: allowedProviders.map((p) => ({ value: p, label: p === "dodopayments" ? "Dodo Payments" : "Stripe payments" })),
+          });
+          if (isCancel(providerChoice)) {
+            cancel("Setup cancelled.");
+            process.exit(0);
+          }
+          providerValue = providerChoice as SupportedProvider;
+        }
+      }
+
+      if (!frameworkValue || !providerValue) {
         cancel("Setup cancelled.");
         process.exit(0);
       }
-
-      const frameworkValue = framework as "nextjs" | "express" | "react" | "fastify" | "hono";
-
-      const providerOptions =
-        frameworkValue === "express" || frameworkValue === "hono"
-          ? [
-              { value: "dodopayments", label: "Dodo Payments" },
-              { value: "stripe", label: "Stripe payments" },
-            ]
-          : [
-              { value: "dodopayments", label: "Dodo Payments" },
-            ];
-
-      const providerChoice = await select({
-        message: "Which payment provider would you like to use? (Adding more providers soon)",
-        options: providerOptions,
-      });
-
-      if (isCancel(providerChoice)) {
-        cancel("Setup cancelled.");
-        process.exit(0);
-      }
-      const provider = providerChoice as "dodopayments" | "stripe";
 
       const s = spinner();
       s.start("Setting up your billing project...");
       try {
-        await addFiles(frameworkValue, provider);
+        await addFiles(frameworkValue, providerValue, {
+          registryBase: opts?.registryBase,
+          cwd: opts?.cwd,
+          installDeps: opts?.noInstall ? false : true
+        });
         s.stop("Setup completed successfully!");
       } catch (error) {
         s.stop("Setup failed!");

--- a/packages/cli/src/config/matrix.ts
+++ b/packages/cli/src/config/matrix.ts
@@ -1,0 +1,34 @@
+export type SupportedFramework = "nextjs" | "express" | "react" | "fastify" | "hono";
+export type SupportedProvider = "dodopayments" | "stripe";
+
+export const supportedFrameworks: SupportedFramework[] = [
+  "nextjs",
+  "express",
+  "react",
+  "fastify",
+  "hono"
+];
+
+export const supportedProviders: SupportedProvider[] = [
+  "dodopayments",
+  "stripe"
+];
+
+// Matrix of valid framework/provider combinations
+export const isValidCombination = (framework: SupportedFramework, provider: SupportedProvider): boolean => {
+  if (provider === "dodopayments") return true;
+  if (provider === "stripe") {
+    return framework === "express" || framework === "hono";
+  }
+  return false;
+};
+
+export const getAllowedProvidersForFramework = (framework: SupportedFramework): SupportedProvider[] => {
+  return supportedProviders.filter((p) => isValidCombination(framework, p));
+};
+
+export const transportNameFor = (framework: SupportedFramework, provider: SupportedProvider): string => {
+  return `${framework}-${provider}`;
+};
+
+

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,7 +15,7 @@ program
   .description("Billing SDK CLI for managing billing components")
   .version("1.0.0");
 
-// if (process.argv.length === 2) {
+if (process.argv.length === 2) {
   render(
     React.createElement(BigTextBanner, {
       text: "Billing\nSDK",
@@ -25,9 +25,7 @@ program
       showSubtitle: false
     })
   );
-  // program.help();
-  // process.exit(0);
-// }
+}
 
 // Register commands
 program.addCommand(initCommand);

--- a/packages/cli/src/scripts/add-files.ts
+++ b/packages/cli/src/scripts/add-files.ts
@@ -1,7 +1,9 @@
 import path from "path";
 import fs from "fs";
-import { Result } from "../types/registry.js";
-import { SupportedFramework, SupportedProvider, transportNameFor } from "../config/matrix.js";
+import { fileURLToPath } from "url";
+import type { Result } from "../types/registry.js";
+import type { SupportedFramework, SupportedProvider } from "../config/matrix.js";
+import { transportNameFor } from "../config/matrix.js";
 import { confirm, spinner, isCancel } from "@clack/prompts";
 import { spawnSync } from "child_process";
 
@@ -46,7 +48,7 @@ export const addFiles = async (
 
     let result: Result;
     if (base.startsWith("file://")) {
-        const filePath = url.replace("file://", "");
+        const filePath = fileURLToPath(url);
         if (!fs.existsSync(filePath)) {
             throw new Error(`Transport not found at ${filePath}. Did you build templates?`);
         }

--- a/packages/cli/src/scripts/add-files.ts
+++ b/packages/cli/src/scripts/add-files.ts
@@ -5,11 +5,31 @@ import { SupportedFramework, SupportedProvider, transportNameFor } from "../conf
 import { confirm, spinner } from "@clack/prompts";
 import { execSync } from "child_process";
 
+type PackageManager = "npm" | "pnpm" | "yarn" | "bun";
+
 type AddFilesOptions = {
     registryBase?: string;
     cwd?: string;
     installDeps?: boolean;
+    forceOverwrite?: boolean;
+    dryRun?: boolean;
+    verbose?: boolean;
+    packageManager?: PackageManager;
 };
+
+function resolvePackageManagerRunner(override?: PackageManager): string {
+    if (override) {
+        if (override === "bun") return "bun add";
+        if (override === "pnpm") return "pnpm add";
+        if (override === "yarn") return "yarn add";
+        return "npm install";
+    }
+    const ua = process.env.npm_config_user_agent || "";
+    if (ua.startsWith("bun")) return "bun add";
+    if (ua.startsWith("pnpm")) return "pnpm add";
+    if (ua.startsWith("yarn")) return "yarn add";
+    return "npm install";
+}
 
 export const addFiles = async (
     framework: SupportedFramework,
@@ -20,11 +40,34 @@ export const addFiles = async (
     const name = transportNameFor(framework, provider);
     const url = `${base.replace(/\/$/, "")}/${name}.json`;
 
-    const result = await fetch(url).then(res => res.json()) as Result;
+    if (options.verbose) {
+        console.log(`Using registry: ${url}`);
+    }
+
+    let result: Result;
+    if (base.startsWith("file://")) {
+        const filePath = url.replace("file://", "");
+        if (!fs.existsSync(filePath)) {
+            console.error(`Transport not found at ${filePath}. Did you build templates?`);
+            process.exit(1);
+        }
+        const json = fs.readFileSync(filePath, "utf-8");
+        result = JSON.parse(json) as Result;
+    } else {
+        const res = await fetch(url);
+        if (!res.ok) {
+            console.error(`Failed to fetch transport from ${url} (status ${res.status}).`);
+            process.exit(1);
+        }
+        result = await res.json() as Result;
+    }
 
     const cwd = options.cwd || process.cwd();
     let srcExists = fs.existsSync(path.join(cwd, "src"));
     const addToPath = srcExists ? "src" : "";
+    if (options.verbose) {
+        console.log(`Placing files under: ${addToPath || "."}`);
+    }
 
     for (const file of result.files) {
         const filePath = path.join(cwd, addToPath, file.target);
@@ -35,34 +78,52 @@ export const addFiles = async (
             fs.mkdirSync(dirPath, { recursive: true });
             const fileName = path.basename(file.target);
 
+            if (options.dryRun) {
+                console.log(`[dry-run] write ${relativePath}`);
+                continue;
+            }
+
             if (fs.existsSync(filePath)) {
                 if (fileName === '.env.example') {
                     const existingContent = fs.readFileSync(filePath, 'utf8');
                     const newContent = existingContent + '\n' + file.content + '\n';
                     fs.writeFileSync(filePath, newContent);
                 } else {
-                    const overwrite = await confirm({
-                        message: `File ${relativePath} already exists. Do you want to overwrite it?`,
-                    });
-                    if (overwrite) {
+                    if (options.forceOverwrite) {
                         fs.writeFileSync(filePath, file.content);
+                    } else {
+                        const overwrite = await confirm({
+                            message: `File ${relativePath} already exists. Do you want to overwrite it?`,
+                        });
+                        if (overwrite) {
+                            fs.writeFileSync(filePath, file.content);
+                        }
                     }
                 }
             } else {
                 fs.writeFileSync(filePath, file.content);
             }
+            if (options.verbose) {
+                console.log(`wrote ${relativePath}`);
+            }
         } catch (error) {
             console.error(`Failed to add file ${relativePath}:`, error);
         }
     }
-    if (result.dependencies && options.installDeps !== false) {
+    if (result.dependencies && options.installDeps !== false && !options.dryRun) {
         const s = spinner();
         s.start("Installing dependencies...");
         try {
-            await execSync(`npm install ${result.dependencies.join(" ")}`, { stdio: "inherit" });
+            const runner = resolvePackageManagerRunner(options.packageManager);
+            if (options.verbose) {
+                console.log(`Installing with: ${runner} ${result.dependencies.join(" ")}`);
+            }
+            await execSync(`${runner} ${result.dependencies.join(" ")}`, { stdio: "inherit" });
             s.stop("Dependencies installed successfully!");
         } catch (error) {
             console.error("Failed to install dependencies:", error);
         }
+    } else if (options.dryRun && result.dependencies?.length) {
+        console.log(`[dry-run] install ${result.dependencies.join(" ")}`);
     }
 }

--- a/packages/cli/src/scripts/add-files.ts
+++ b/packages/cli/src/scripts/add-files.ts
@@ -2,8 +2,8 @@ import path from "path";
 import fs from "fs";
 import { Result } from "../types/registry.js";
 import { SupportedFramework, SupportedProvider, transportNameFor } from "../config/matrix.js";
-import { confirm, spinner } from "@clack/prompts";
-import { execSync } from "child_process";
+import { confirm, spinner, isCancel } from "@clack/prompts";
+import { spawnSync } from "child_process";
 
 type PackageManager = "npm" | "pnpm" | "yarn" | "bun";
 
@@ -48,16 +48,14 @@ export const addFiles = async (
     if (base.startsWith("file://")) {
         const filePath = url.replace("file://", "");
         if (!fs.existsSync(filePath)) {
-            console.error(`Transport not found at ${filePath}. Did you build templates?`);
-            process.exit(1);
+            throw new Error(`Transport not found at ${filePath}. Did you build templates?`);
         }
         const json = fs.readFileSync(filePath, "utf-8");
         result = JSON.parse(json) as Result;
     } else {
         const res = await fetch(url);
         if (!res.ok) {
-            console.error(`Failed to fetch transport from ${url} (status ${res.status}).`);
-            process.exit(1);
+            throw new Error(`Failed to fetch transport from ${url} (status ${res.status}).`);
         }
         result = await res.json() as Result;
     }
@@ -70,38 +68,50 @@ export const addFiles = async (
     }
 
     for (const file of result.files) {
-        const filePath = path.join(cwd, addToPath, file.target);
-        const dirPath = path.dirname(filePath);
-        const relativePath = addToPath ? path.join(addToPath, file.target) : file.target;
+        if (path.isAbsolute(file.target) || file.target.split(path.sep).some((seg) => seg === "..")) {
+            throw new Error(`Refusing to write outside project: invalid target '${file.target}'`);
+        }
+        const combined = path.join(addToPath, file.target);
+        const resolved = path.resolve(cwd, combined);
+        const resolvedCwd = path.resolve(cwd);
+        if (!resolved.startsWith(resolvedCwd + path.sep) && resolved !== resolvedCwd) {
+            throw new Error(`Resolved path escapes project directory: '${resolved}'`);
+        }
+        const dirPath = path.dirname(resolved);
+        const relativePath = path.relative(cwd, resolved) || path.basename(resolved);
 
         try {
-            fs.mkdirSync(dirPath, { recursive: true });
             const fileName = path.basename(file.target);
 
             if (options.dryRun) {
+                console.log(`[dry-run] mkdir ${path.relative(cwd, dirPath) || "."}`);
                 console.log(`[dry-run] write ${relativePath}`);
                 continue;
             }
 
-            if (fs.existsSync(filePath)) {
+            fs.mkdirSync(dirPath, { recursive: true });
+
+            if (fs.existsSync(resolved)) {
                 if (fileName === '.env.example') {
-                    const existingContent = fs.readFileSync(filePath, 'utf8');
+                    const existingContent = fs.readFileSync(resolved, 'utf8');
                     const newContent = existingContent + '\n' + file.content + '\n';
-                    fs.writeFileSync(filePath, newContent);
+                    fs.writeFileSync(resolved, newContent);
                 } else {
                     if (options.forceOverwrite) {
-                        fs.writeFileSync(filePath, file.content);
+                        fs.writeFileSync(resolved, file.content);
                     } else {
                         const overwrite = await confirm({
                             message: `File ${relativePath} already exists. Do you want to overwrite it?`,
                         });
-                        if (overwrite) {
-                            fs.writeFileSync(filePath, file.content);
+                        if (isCancel(overwrite)) {
+                            // skip on cancel
+                        } else if (overwrite === true) {
+                            fs.writeFileSync(resolved, file.content);
                         }
                     }
                 }
             } else {
-                fs.writeFileSync(filePath, file.content);
+                fs.writeFileSync(resolved, file.content);
             }
             if (options.verbose) {
                 console.log(`wrote ${relativePath}`);
@@ -113,16 +123,19 @@ export const addFiles = async (
     if (result.dependencies && options.installDeps !== false && !options.dryRun) {
         const s = spinner();
         s.start("Installing dependencies...");
-        try {
-            const runner = resolvePackageManagerRunner(options.packageManager);
-            if (options.verbose) {
-                console.log(`Installing with: ${runner} ${result.dependencies.join(" ")}`);
-            }
-            await execSync(`${runner} ${result.dependencies.join(" ")}`, { stdio: "inherit" });
-            s.stop("Dependencies installed successfully!");
-        } catch (error) {
-            console.error("Failed to install dependencies:", error);
+        const runner = resolvePackageManagerRunner(options.packageManager);
+        const [cmdRaw, ...baseArgs] = runner.split(" ");
+        const cmd = cmdRaw || "npm";
+        const args = [...baseArgs, ...result.dependencies];
+        if (options.verbose) {
+            console.log(`Installing with: ${cmd} ${args.join(" ")}`);
         }
+        const res = spawnSync(cmd, args, { stdio: "inherit", shell: false });
+        if (res.error || (typeof res.status === "number" && res.status !== 0)) {
+            s.stop("Failed to install dependencies!");
+            throw res.error || new Error(`Installer exited with status ${res.status}`);
+        }
+        s.stop("Dependencies installed successfully!");
     } else if (options.dryRun && result.dependencies?.length) {
         console.log(`[dry-run] install ${result.dependencies.join(" ")}`);
     }

--- a/packages/cli/src/scripts/add-files.ts
+++ b/packages/cli/src/scripts/add-files.ts
@@ -104,7 +104,7 @@ export const addFiles = async (
                             message: `File ${relativePath} already exists. Do you want to overwrite it?`,
                         });
                         if (isCancel(overwrite)) {
-                            // skip on cancel
+                            throw new Error("Setup cancelled by user during overwrite prompt");
                         } else if (overwrite === true) {
                             fs.writeFileSync(resolved, file.content);
                         }

--- a/packages/cli/src/types/registry.ts
+++ b/packages/cli/src/types/registry.ts
@@ -1,7 +1,9 @@
+import { SupportedFramework } from "../config/matrix.js";
+
 export interface BackendComponent {
     name: string;
     description: string;
-    framework: "nextjs" | "express" | "react" | "fastify";
+    framework: SupportedFramework;
     files: Array<{
         path: string;
         content: string;
@@ -19,7 +21,7 @@ export interface Registry {
 export interface Result {
     name: string;
     description: string;
-    framework: "nextjs" | "express" | "react" | "fastify";
+    framework: SupportedFramework;
     files: Array<{
         content: string;
         target: string;


### PR DESCRIPTION
### Summary
Refactors the BillingSDK CLI to support non-interactive flags, centralizes framework/provider configuration, simplifies local testing via a configurable registry, and updates documentation for clearer contributor setup.

### Changes
- CLI
  - Added flags: `--framework`, `--provider`, `--yes`, `--no-install`, `--registry-base`, `--cwd`, `--force`, `--dry-run`, `--verbose`, `--package-manager <npm|pnpm|yarn|bun>`.
  - Centralized framework/provider support and validation in `packages/cli/src/config/matrix.ts`.
  - Improved `addFiles` to support:
    - File-based registry (`file://`) for local testing
    - Force overwrite and dry-run
    - Verbose output (registry URL, placement, actions)
    - Package manager override for installs
    - Clear validation/error if transport JSON missing/unreachable
  - Render banner only on bare invocation (no subcommand/args).
- Types
  - `types/registry.ts` derives frameworks from matrix (includes `hono`).
- Docs
  - `packages/cli/README.md`: documented all new flags and local testing flow.
  - `CONTRIBUTING.md`: added CLI local dev/testing section and flags.

### How to Test
1. npm ci
2. Build transports locally:
   - node packages/cli/dist/index.js build
3. Non-interactive init (local file registry):
   - BILLINGSDK_REGISTRY_BASE=file://$PWD/public/tr node packages/cli/dist/index.js init --framework express --provider dodopayments --yes --cwd /tmp/app --no-install --verbose
4. Dry-run:
   - BILLINGSDK_REGISTRY_BASE=file://$PWD/public/tr node packages/cli/dist/index.js init --framework nextjs --provider dodopayments --yes --cwd /tmp/app --dry-run --verbose
5. Force overwrite:
   - Repeat init with `--force` to overwrite without prompts.

### Checklist
- [x] Title is clear and descriptive
- [ ] Related issue linked (if any)
- [x] Tests or manual verification steps included (smoke steps above)
- [x] CI passes (typecheck & build)
- [x] Docs updated (README and CONTRIBUTING)