### PR TITLE
feat: added stripe support to react

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9614,9 +9614,7 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.13.tgz",
-      "integrity": "sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w==",
+      "version": "4.1.11",
       "devOptional": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9614,7 +9614,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.1.11",
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.13.tgz",
+      "integrity": "sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w==",
       "devOptional": true,
       "license": "MIT"
     },

--- a/packages/templates/react/hooks/dodopayments/useBilling.ts
+++ b/packages/templates/react/hooks/dodopayments/useBilling.ts
@@ -1,5 +1,5 @@
-import { useState, useCallback } from 'react'
-import { DodoPayments } from 'dodopayments'
+import { useState, useCallback } from "react";
+import { DodoPayments } from "dodopayments";
 import {
   getProducts,
   getProduct,
@@ -9,123 +9,126 @@ import {
   createCustomer,
   updateCustomer,
   checkout,
-} from '../lib/dodopayments'
-
+} from "../../lib/dodopayments";
 
 interface UseBillingState {
-  loading: boolean
-  error: string | null
+  loading: boolean;
+  error: string | null;
 }
 
 export function useBilling({ baseUrl }: { baseUrl?: string } = {}) {
   const resolvedBaseUrl =
-    baseUrl ?? process.env.VITE_BASE_URL ?? 'http://localhost:8080'
+    baseUrl ?? process.env.VITE_BASE_URL ?? "http://localhost:8080";
 
   const [state, setState] = useState<UseBillingState>({
     loading: false,
     error: null,
-  })
+  });
 
-  const [products, setProducts] = useState<DodoPayments.Product[]>([])
-  const [customer, setCustomer] = useState<DodoPayments.Customers.Customer | null>(null)
+  const [products, setProducts] = useState<DodoPayments.Product[]>([]);
+  const [customer, setCustomer] =
+    useState<DodoPayments.Customers.Customer | null>(null);
 
-  
   const setLoading = useCallback((loading: boolean) => {
-    setState(prev => ({ ...prev, loading }))
-  }, [])
+    setState((prev) => ({ ...prev, loading }));
+  }, []);
 
   const setError = useCallback((error: string | null) => {
-    setState(prev => ({ ...prev, error }))
-  }, [])
-
+    setState((prev) => ({ ...prev, error }));
+  }, []);
 
   const handleAsyncOperation = useCallback(
-    async <T>(operation: () => Promise<T>, operationName: string): Promise<T> => {
+    async <T>(
+      operation: () => Promise<T>,
+      operationName: string
+    ): Promise<T> => {
       try {
-        setLoading(true)
-        setError(null)
-        const result = await operation()
-        return result
+        setLoading(true);
+        setError(null);
+        const result = await operation();
+        return result;
       } catch (error) {
         const errorMessage =
-          error instanceof Error ? error.message : `Failed to ${operationName}`
-        setError(errorMessage)
-        throw error
+          error instanceof Error ? error.message : `Failed to ${operationName}`;
+        setError(errorMessage);
+        throw error;
       } finally {
-        setLoading(false)
+        setLoading(false);
       }
     },
     [setLoading, setError]
-  )
+  );
 
-
-  const fetchProducts = useCallback(async (): Promise<DodoPayments.Product[]> => {
+  const fetchProducts = useCallback(async (): Promise<
+    DodoPayments.Product[]
+  > => {
     const result = await handleAsyncOperation(
       () => getProducts({ baseUrl: resolvedBaseUrl }),
-      'fetch products'
-    )
-    setProducts(result)
-    return result
-  }, [handleAsyncOperation, resolvedBaseUrl])
+      "fetch products"
+    );
+    setProducts(result);
+    return result;
+  }, [handleAsyncOperation, resolvedBaseUrl]);
 
   const fetchProduct = useCallback(
     async (product_id: string): Promise<DodoPayments.Product> => {
       return handleAsyncOperation(
         () => getProduct({ baseUrl: resolvedBaseUrl, product_id }),
-        'fetch product'
-      )
+        "fetch product"
+      );
     },
     [handleAsyncOperation, resolvedBaseUrl]
-  )
+  );
 
-  
   const fetchCustomer = useCallback(
     async (customer_id: string): Promise<DodoPayments.Customers.Customer> => {
       const result = await handleAsyncOperation(
         () => getCustomer({ baseUrl: resolvedBaseUrl, customer_id }),
-        'fetch customer'
-      )
-      setCustomer(result)
-      return result
+        "fetch customer"
+      );
+      setCustomer(result);
+      return result;
     },
     [handleAsyncOperation, resolvedBaseUrl]
-  )
+  );
 
   const fetchCustomerSubscriptions = useCallback(
     async (
       customer_id: string
     ): Promise<DodoPayments.Subscriptions.Subscription[]> => {
       return handleAsyncOperation(
-        () => getCustomerSubscriptions({ baseUrl: resolvedBaseUrl, customer_id }),
-        'fetch customer subscriptions'
-      )
+        () =>
+          getCustomerSubscriptions({ baseUrl: resolvedBaseUrl, customer_id }),
+        "fetch customer subscriptions"
+      );
     },
     [handleAsyncOperation, resolvedBaseUrl]
-  )
+  );
 
   const fetchCustomerPayments = useCallback(
     async (customer_id: string): Promise<DodoPayments.Payments.Payment[]> => {
       return handleAsyncOperation(
         () => getCustomerPayments({ baseUrl: resolvedBaseUrl, customer_id }),
-        'fetch customer payments'
-      )
+        "fetch customer payments"
+      );
     },
     [handleAsyncOperation, resolvedBaseUrl]
-  )
+  );
 
   const createNewCustomer = useCallback(
     async (
       newCustomer: DodoPayments.Customers.CustomerCreateParams
     ): Promise<DodoPayments.Customers.Customer> => {
       const result = await handleAsyncOperation(
-        () => createCustomer({ baseUrl: resolvedBaseUrl, customer: newCustomer }),
-        'create customer'
-      )
-      setCustomer(result)
-      return result
+        () =>
+          createCustomer({ baseUrl: resolvedBaseUrl, customer: newCustomer }),
+        "create customer"
+      );
+      setCustomer(result);
+      return result;
     },
     [handleAsyncOperation, resolvedBaseUrl]
-  )
+  );
 
   const updateExistingCustomer = useCallback(
     async (
@@ -139,18 +142,21 @@ export function useBilling({ baseUrl }: { baseUrl?: string } = {}) {
             customer_id,
             customer: updatedCustomer,
           }),
-        'update customer'
-      )
-      setCustomer(result)
-      return result
+        "update customer"
+      );
+      setCustomer(result);
+      return result;
     },
     [handleAsyncOperation, resolvedBaseUrl]
-  )
+  );
 
-  
   const createCheckout = useCallback(
     async (
-      productCart: Array<{ product_id: string; quantity: number; amount?: number }>,
+      productCart: Array<{
+        product_id: string;
+        quantity: number;
+        amount?: number;
+      }>,
       customer: DodoPayments.Payments.CustomerRequest,
       billing_address: DodoPayments.Payments.BillingAddress,
       return_url: string,
@@ -166,24 +172,22 @@ export function useBilling({ baseUrl }: { baseUrl?: string } = {}) {
             return_url,
             customMetadata,
           }),
-        'create checkout'
-      )
+        "create checkout"
+      );
     },
     [handleAsyncOperation, resolvedBaseUrl]
-  )
+  );
 
   const clearError = useCallback(() => {
-    setError(null)
-  }, [setError])
+    setError(null);
+  }, [setError]);
 
-  
   return {
-    
     loading: state.loading,
     error: state.error,
     products,
-    customer,    
-    clearError,   
+    customer,
+    clearError,
     fetchProducts,
     fetchProduct,
     fetchCustomer,
@@ -192,5 +196,5 @@ export function useBilling({ baseUrl }: { baseUrl?: string } = {}) {
     createNewCustomer,
     updateExistingCustomer,
     createCheckout,
-  }
+  };
 }

--- a/packages/templates/react/hooks/stripe/useBilling.ts
+++ b/packages/templates/react/hooks/stripe/useBilling.ts
@@ -1,0 +1,189 @@
+import { useState, useCallback } from "react";
+import Stripe from "stripe";
+import {
+  getProducts,
+  getProduct,
+  getCustomer,
+  getCustomerSubscriptions,
+  getCustomerPayments,
+  createCustomer,
+  updateCustomer,
+  checkout,
+} from "../../lib/stripe";
+
+interface UseBillingState {
+  loading: boolean;
+  error: string | null;
+}
+
+export function useBilling({ baseUrl }: { baseUrl?: string } = {}) {
+  const resolvedBaseUrl =
+    baseUrl ?? process.env.VITE_BASE_URL ?? "http://localhost:8080";
+
+  const [state, setState] = useState<UseBillingState>({
+    loading: false,
+    error: null,
+  });
+
+  const [products, setProducts] = useState<Stripe.Product[]>([]);
+  const [customer, setCustomer] = useState<Stripe.Customer | null>(null);
+
+  const setLoading = useCallback((loading: boolean) => {
+    setState((prev) => ({ ...prev, loading }));
+  }, []);
+
+  const setError = useCallback((error: string | null) => {
+    setState((prev) => ({ ...prev, error }));
+  }, []);
+
+  const handleAsyncOperation = useCallback(
+    async <T>(
+      operation: () => Promise<T>,
+      operationName: string
+    ): Promise<T> => {
+      try {
+        setLoading(true);
+        setError(null);
+        const result = await operation();
+        return result;
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : `Failed to ${operationName}`;
+        setError(errorMessage);
+        throw error;
+      } finally {
+        setLoading(false);
+      }
+    },
+    [setLoading, setError]
+  );
+
+  const fetchProducts = useCallback(async (): Promise<Stripe.Product[]> => {
+    const result = await handleAsyncOperation(
+      () => getProducts({ baseUrl: resolvedBaseUrl }),
+      "fetch products"
+    );
+    setProducts(result);
+    return result;
+  }, [handleAsyncOperation, resolvedBaseUrl]);
+
+  const fetchProduct = useCallback(
+    async (product_id: string): Promise<Stripe.Product> => {
+      return handleAsyncOperation(
+        () => getProduct({ baseUrl: resolvedBaseUrl, product_id }),
+        "fetch product"
+      );
+    },
+    [handleAsyncOperation, resolvedBaseUrl]
+  );
+
+  const fetchCustomer = useCallback(
+    async (customer_id: string): Promise<Stripe.Customer> => {
+      const result = await handleAsyncOperation(
+        () => getCustomer({ baseUrl: resolvedBaseUrl, customer_id }),
+        "fetch customer"
+      );
+      setCustomer(result);
+      return result;
+    },
+    [handleAsyncOperation, resolvedBaseUrl]
+  );
+
+  const fetchCustomerSubscriptions = useCallback(
+    async (customer_id: string): Promise<Stripe.Subscription[]> => {
+      return handleAsyncOperation(
+        () =>
+          getCustomerSubscriptions({ baseUrl: resolvedBaseUrl, customer_id }),
+        "fetch customer subscriptions"
+      );
+    },
+    [handleAsyncOperation, resolvedBaseUrl]
+  );
+
+  const fetchCustomerPayments = useCallback(
+    async (customer_id: string): Promise<Stripe.PaymentIntent[]> => {
+      return handleAsyncOperation(
+        () => getCustomerPayments({ baseUrl: resolvedBaseUrl, customer_id }),
+        "fetch customer payments"
+      );
+    },
+    [handleAsyncOperation, resolvedBaseUrl]
+  );
+
+  const createNewCustomer = useCallback(
+    async (
+      newCustomer: Stripe.CustomerCreateParams
+    ): Promise<Stripe.Customer> => {
+      const result = await handleAsyncOperation(
+        () =>
+          createCustomer({ baseUrl: resolvedBaseUrl, customer: newCustomer }),
+        "create customer"
+      );
+      setCustomer(result);
+      return result;
+    },
+    [handleAsyncOperation, resolvedBaseUrl]
+  );
+
+  const updateExistingCustomer = useCallback(
+    async (
+      customer_id: string,
+      updatedCustomer: Stripe.CustomerUpdateParams
+    ): Promise<Stripe.Customer> => {
+      const result = await handleAsyncOperation(
+        () =>
+          updateCustomer({
+            baseUrl: resolvedBaseUrl,
+            customer_id,
+            customer: updatedCustomer,
+          }),
+        "update customer"
+      );
+      setCustomer(result);
+      return result;
+    },
+    [handleAsyncOperation, resolvedBaseUrl]
+  );
+
+  const createCheckout = useCallback(
+    async (
+      price_id: string,
+      success_url: string,
+      cancel_url: string,
+      customer_id?: string
+    ) => {
+      return handleAsyncOperation(
+        () =>
+          checkout({
+            baseUrl: resolvedBaseUrl,
+            price_id,
+            customer_id,
+            success_url,
+            cancel_url,
+          }),
+        "create checkout"
+      );
+    },
+    [handleAsyncOperation, resolvedBaseUrl]
+  );
+
+  const clearError = useCallback(() => {
+    setError(null);
+  }, [setError]);
+
+  return {
+    loading: state.loading,
+    error: state.error,
+    products,
+    customer,
+    clearError,
+    fetchProducts,
+    fetchProduct,
+    fetchCustomer,
+    fetchCustomerSubscriptions,
+    fetchCustomerPayments,
+    createNewCustomer,
+    updateExistingCustomer,
+    createCheckout,
+  };
+}

--- a/packages/templates/react/lib/stripe.ts
+++ b/packages/templates/react/lib/stripe.ts
@@ -1,0 +1,161 @@
+import Stripe from "stripe";
+
+export type Product = Stripe.Product;
+export type Customer = Stripe.Customer;
+export type Subscription = Stripe.Subscription;
+export type PaymentIntent = Stripe.PaymentIntent;
+
+export const getProducts = async ({
+  baseUrl,
+}: {
+  baseUrl: string;
+}): Promise<Product[]> => {
+  const response = await fetch(`${baseUrl}/products`);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch products: ${response.status} ${response.statusText}`
+    );
+  }
+  return response.json();
+};
+
+export const getProduct = async ({
+  baseUrl,
+  product_id,
+}: {
+  baseUrl: string;
+  product_id: string;
+}): Promise<Product> => {
+  const response = await fetch(`${baseUrl}/product?product_id=${product_id}`);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch product: ${response.status} ${response.statusText}`
+    );
+  }
+  return response.json();
+};
+
+export const getCustomer = async ({
+  baseUrl,
+  customer_id,
+}: {
+  baseUrl: string;
+  customer_id: string;
+}): Promise<Customer> => {
+  const response = await fetch(
+    `${baseUrl}/customer?customer_id=${customer_id}`
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch customer: ${response.status} ${response.statusText}`
+    );
+  }
+  return response.json();
+};
+
+export const getCustomerSubscriptions = async ({
+  baseUrl,
+  customer_id,
+}: {
+  baseUrl: string;
+  customer_id: string;
+}): Promise<Subscription[]> => {
+  const response = await fetch(
+    `${baseUrl}/customer/subscriptions?customer_id=${customer_id}`
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch subscriptions: ${response.status} ${response.statusText}`
+    );
+  }
+  return response.json();
+};
+
+export const getCustomerPayments = async ({
+  baseUrl,
+  customer_id,
+}: {
+  baseUrl: string;
+  customer_id: string;
+}): Promise<PaymentIntent[]> => {
+  const response = await fetch(
+    `${baseUrl}/customer/payments?customer_id=${customer_id}`
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch payments: ${response.status} ${response.statusText}`
+    );
+  }
+  return response.json();
+};
+
+export const createCustomer = async ({
+  baseUrl,
+  customer,
+}: {
+  baseUrl: string;
+  customer: Stripe.CustomerCreateParams;
+}): Promise<Customer> => {
+  const response = await fetch(`${baseUrl}/customer`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(customer),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Failed to create customer: ${response.status} ${response.statusText}`
+    );
+  }
+  return response.json();
+};
+
+export const updateCustomer = async ({
+  baseUrl,
+  customer_id,
+  customer,
+}: {
+  baseUrl: string;
+  customer_id: string;
+  customer: Stripe.CustomerUpdateParams;
+}): Promise<Customer> => {
+  const response = await fetch(
+    `${baseUrl}/customer?customer_id=${customer_id}`,
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(customer),
+    }
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Failed to update customer: ${response.status} ${response.statusText}`
+    );
+  }
+  return response.json();
+};
+
+export const checkout = async ({
+  baseUrl,
+  price_id,
+  customer_id,
+  success_url,
+  cancel_url,
+}: {
+  baseUrl: string;
+  price_id: string;
+  customer_id?: string;
+  success_url: string;
+  cancel_url: string;
+}): Promise<{ checkout_url: string }> => {
+  const response = await fetch(`${baseUrl}/checkout`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ price_id, customer_id, success_url, cancel_url }),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Failed to checkout: ${response.status} ${response.statusText}`
+    );
+  }
+  return response.json();
+};

--- a/packages/templates/registry.json
+++ b/packages/templates/registry.json
@@ -175,10 +175,10 @@
           "target": "lib/dodopayments.ts"
         },
         {
-          "path": "packages/templates/react/hooks/useBilling.ts",
+          "path": "packages/templates/react/hooks/dodopayments/useBilling.ts",
           "content": "Custom React hook for managing DodoPayments billing flows",
           "type": "template",
-          "target": "hooks/useBilling.ts"
+          "target": "hooks/dodopayments/useBilling.ts"
         },
         {
           "path": "packages/templates/react/.env.example",

--- a/packages/templates/registry.json
+++ b/packages/templates/registry.json
@@ -1,443 +1,417 @@
 {
-    "components": [
+  "components": [
+    {
+      "name": "nextjs-dodopayments",
+      "description": "DodoPayments template for NextJS",
+      "framework": "nextjs",
+      "files": [
         {
-            "name": "nextjs-dodopayments",
-            "description": "DodoPayments template for NextJS",
-            "framework": "nextjs",
-            "files": [
-                {
-                    "path": "packages/templates/nextjs/lib/dodopayments.ts",
-                    "content": "DodoPayments library for NextJS",
-                    "type": "template",
-                    "target": "lib/dodopayments.ts"
-                },
-                {
-                    "path": "packages/templates/nextjs/hooks/useBilling.ts",
-                    "content": "useBilling hook for NextJS",
-                    "type": "template",
-                    "target": "hooks/useBilling.ts"
-                },
-                {
-                    "path": "packages/templates/nextjs/api-routes/*",
-                    "content": "DodoPayments API routes for NextJS",
-                    "type": "template",
-                    "target": "app/api/*"
-                },
-                {
-                    "path": "packages/templates/nextjs/.env.example",
-                    "content": "DodoPayments .env.example for NextJS",
-                    "type": "template",
-                    "target": ".env.example"
-                }
-            ],
-            "dependencies": [
-                "dodopayments",
-                "standardwebhooks",
-                "zod"
-            ]
+          "path": "packages/templates/nextjs/lib/dodopayments.ts",
+          "content": "DodoPayments library for NextJS",
+          "type": "template",
+          "target": "lib/dodopayments.ts"
         },
         {
-            "name": "express-dodopayments",
-            "description": "DodoPayments template for Express.js",
-            "framework": "express",
-            "files": [
-                {
-                    "path": "packages/templates/express/src/lib/dodopayments.ts",
-                    "content": "DodoPayments library for Express.js",
-                    "type": "template",
-                    "target": "lib/dodopayments.ts"
-                },
-                {
-                    "path": "packages/templates/express/src/routes/dodopayments/route.ts",
-                    "content": "Main DodoPayments router for Express.js",
-                    "type": "template",
-                    "target": "routes/dodopayments/route.ts"
-                },
-                {
-                    "path": "packages/templates/express/src/routes/dodopayments/checkout.ts",
-                    "content": "Checkout routes for Express.js",
-                    "type": "template",
-                    "target": "routes/dodopayments/checkout.ts"
-                },
-                {
-                    "path": "packages/templates/express/src/routes/dodopayments/customer.ts",
-                    "content": "Customer management routes for Express.js",
-                    "type": "template",
-                    "target": "routes/dodopayments/customer.ts"
-                },
-                {
-                    "path": "packages/templates/express/src/routes/dodopayments/payments.ts",
-                    "content": "Payment routes for Express.js",
-                    "type": "template",
-                    "target": "routes/dodopayments/payments.ts"
-                },
-                {
-                    "path": "packages/templates/express/src/routes/dodopayments/products.ts",
-                    "content": "Product management routes for Express.js",
-                    "type": "template",
-                    "target": "routes/dodopayments/products.ts"
-                },
-                {
-                    "path": "packages/templates/express/src/routes/dodopayments/subscriptions.ts",
-                    "content": "Subscription management routes for Express.js",
-                    "type": "template",
-                    "target": "routes/dodopayments/subscriptions.ts"
-                },
-                {
-                    "path": "packages/templates/express/src/routes/dodopayments/webhook.ts",
-                    "content": "Webhook handling routes for Express.js",
-                    "type": "template",
-                    "target": "routes/dodopayments/webhook.ts"
-                },
-                {
-                    "path": "packages/templates/express/.env.example",
-                    "content": "DodoPayments .env.example for Express.js",
-                    "type": "template",
-                    "target": ".env.example"
-                }
-            ],
-            "dependencies": [
-                "dodopayments",
-                "standardwebhooks",
-                "zod",
-                "express",
-                "@types/express"
-            ]
+          "path": "packages/templates/nextjs/hooks/useBilling.ts",
+          "content": "useBilling hook for NextJS",
+          "type": "template",
+          "target": "hooks/useBilling.ts"
         },
         {
-            "name": "express-stripe",
-            "description": "Stripe template for Express.js",
-            "framework": "express",
-            "files": [
-                {
-                    "path": "packages/templates/express/src/lib/stripe.ts",
-                    "content": "Stripe client setup for Express.js",
-                    "type": "template",
-                    "target": "lib/stripe.ts"
-                },
-                {
-                    "path": "packages/templates/express/src/routes/stripe/route.ts",
-                    "content": "Main DodoPayments router for Express.js",
-                    "type": "template",
-                    "target": "routes/stripe/route.ts"
-                },
-                
-                {
-                    "path": "packages/templates/express/src/routes/stripe/checkout.ts",
-                    "content": "Stripe checkout routes",
-                    "type": "template",
-                    "target": "routes/stripe/checkout.ts"
-                },
-                {
-                    "path": "packages/templates/express/src/routes/stripe/customer.ts",
-                    "content": "Stripe customer routes",
-                    "type": "template",
-                    "target": "routes/stripe/customer.ts"
-                },
-                {
-                    "path": "packages/templates/express/src/routes/stripe/payments.ts",
-                    "content": "Stripe payments routes",
-                    "type": "template",
-                    "target": "routes/stripe/payments.ts"
-                },
-                {
-                    "path": "packages/templates/express/src/routes/stripe/products.ts",
-                    "content": "Stripe product routes",
-                    "type": "template",
-                    "target": "routes/stripe/products.ts"
-                },
-                {
-                    "path": "packages/templates/express/src/routes/stripe/subscriptions.ts",
-                    "content": "Stripe checkout routes",
-                    "type": "template",
-                    "target": "routes/stripe/subscriptions.ts"
-                },
-                {
-                    "path": "packages/templates/express/src/routes/stripe/webhook.ts",
-                    "content": "Webhook handling routes for Express.js",
-                    "type": "template",
-                    "target": "routes/stripe/webhook.ts"
-                },
-                {
-                    "path": "packages/templates/express/.env.example",
-                    "content": "Stripe .env.example for Express.js",
-                    "type": "template",
-                    "target": ".env.example"
-                }
-            ],
-            "dependencies": [
-                "stripe",
-                "express",
-                "zod",
-                "@types/express"
-            ]
-      },
-        {
-            "name": "react-dodopayments",
-            "description": "DodoPayments template for React.js",
-            "framework": "react",
-            "files": [
-                {
-                "path": "packages/templates/react/lib/dodopayments.ts",
-                "content": "DodoPayments library for React.js",
-                "type": "template",
-                "target": "lib/dodopayments.ts"
-                },
-                {
-                "path": "packages/templates/react/hooks/useBilling.ts",
-                "content": "Custom React hook for managing DodoPayments billing flows",
-                "type": "template",
-                "target": "hooks/useBilling.ts"
-                },
-                {
-                "path": "packages/templates/react/.env.example",
-                "content": "DodoPayments .env.example for React.js",
-                "type": "template",
-                "target": ".env.example"
-                }
-            ],
-            "dependencies": [
-                "dodopayments",
-                "react"
-            ]
+          "path": "packages/templates/nextjs/api-routes/*",
+          "content": "DodoPayments API routes for NextJS",
+          "type": "template",
+          "target": "app/api/*"
         },
         {
-            "name": "fastify-dodopayments",
-            "description": "DodoPayments template for Fastify",
-            "framework": "fastify",
-            "files": [
-                {
-                    "path": "packages/templates/fastify/src/lib/dodopayments.ts",
-                    "content": "DodoPayments library for Fastify",
-                    "type": "template",
-                    "target": "lib/dodopayments.ts"
-                },
-                {
-                    "path": "packages/templates/fastify/src/routes/dodopayments/route.ts",
-                    "content": "Main DodoPayments routes for Fastify",
-                    "type": "template",
-                    "target": "routes/dodopayments/route.ts"
-                },
-                {
-                    "path": "packages/templates/fastify/src/routes/dodopayments/checkout.ts",
-                    "content": "Checkout routes for Fastify",
-                    "type": "template",
-                    "target": "routes/dodopayments/checkout.ts"
-                },
-                {
-                    "path": "packages/templates/fastify/src/routes/dodopayments/customer.ts",
-                    "content": "Customer management routes for Fastify",
-                    "type": "template",
-                    "target": "routes/dodopayments/customer.ts"
-                },
-                {
-                    "path": "packages/templates/fastify/src/routes/dodopayments/payments.ts",
-                    "content": "Payment routes for Fastify",
-                    "type": "template",
-                    "target": "routes/dodopayments/payments.ts"
-                },
-                {
-                    "path": "packages/templates/fastify/src/routes/dodopayments/products.ts",
-                    "content": "Product management routes for Fastify",
-                    "type": "template",
-                    "target": "routes/dodopayments/products.ts"
-                },
-                {
-                    "path": "packages/templates/fastify/src/routes/dodopayments/subscriptions.ts",
-                    "content": "Subscription management routes for Fastify",
-                    "type": "template",
-                    "target": "routes/dodopayments/subscriptions.ts"
-                },
-                {
-                    "path": "packages/templates/fastify/src/routes/dodopayments/webhook.ts",
-                    "content": "Webhook handling routes for Fastify",
-                    "type": "template",
-                    "target": "routes/dodopayments/webhook.ts"
-                },
-                {
-                    "path": "packages/templates/fastify/.env.example",
-                    "content": "DodoPayments .env.example for Fastify",
-                    "type": "template",
-                    "target": ".env.example"
-                }
-            ],
-            "dependencies": [
-                "dodopayments",
-                "standardwebhooks",
-                "zod",
-                "fastify",
-                "fastify-raw-body"
-            ]
+          "path": "packages/templates/nextjs/.env.example",
+          "content": "DodoPayments .env.example for NextJS",
+          "type": "template",
+          "target": ".env.example"
+        }
+      ],
+      "dependencies": ["dodopayments", "standardwebhooks", "zod"]
+    },
+    {
+      "name": "express-dodopayments",
+      "description": "DodoPayments template for Express.js",
+      "framework": "express",
+      "files": [
+        {
+          "path": "packages/templates/express/src/lib/dodopayments.ts",
+          "content": "DodoPayments library for Express.js",
+          "type": "template",
+          "target": "lib/dodopayments.ts"
         },
         {
-            "name": "hono-dodopayments",
-            "description": "DodoPayments template for Hono",
-            "framework": "hono",
-            "files": [
-                {
-                    "path": "packages/templates/hono/src/lib/dodopayments.ts",
-                    "content": "DodoPayments library for Hono",
-                    "type": "template",
-                    "target": "lib/dodopayments.ts"
-                },
-                {
-                    "path": "packages/templates/hono/src/routes/route.ts",
-                    "content": "Main DodoPayments router for Hono",
-                    "type": "template",
-                    "target": "routes/route.ts"
-                },
-                {
-                    "path": "packages/templates/hono/src/routes/dodopayments/checkout.ts",
-                    "content": "Checkout routes for Hono",
-                    "type": "template",
-                    "target": "routes/dodopayments/checkout.ts"
-                },
-                {
-                    "path": "packages/templates/hono/src/routes/dodopayments/customer.ts",
-                    "content": "Customer management routes for Hono",
-                    "type": "template",
-                    "target": "routes/dodopayments/customer.ts"
-                },
-                {
-                    "path": "packages/templates/hono/src/routes/dodopayments/payments.ts",
-                    "content": "Payment routes for Hono",
-                    "type": "template",
-                    "target": "routes/dodopayments/payments.ts"
-                },
-                {
-                    "path": "packages/templates/hono/src/routes/dodopayments/products.ts",
-                    "content": "Product management routes for Hono",
-                    "type": "template",
-                    "target": "routes/dodopayments/products.ts"
-                },
-                {
-                    "path": "packages/templates/hono/src/routes/dodopayments/subscriptions.ts",
-                    "content": "Subscription management routes for Hono",
-                    "type": "template",
-                    "target": "routes/dodopayments/subscriptions.ts"
-                },
-                {
-                    "path": "packages/templates/hono/src/routes/dodopayments/webhook.ts",
-                    "content": "Webhook handling routes for Hono",
-                    "type": "template",
-                    "target": "routes/dodopayments/webhook.ts"
-                },
-                {
-                    "path": "packages/templates/hono/.env.example",
-                    "content": "DodoPayments .env.example for Hono",
-                    "type": "template",
-                    "target": ".env.example"
-                }
-            ],
-            "dependencies": [
-                "dodopayments",
-                "standardwebhooks",
-                "zod",
-                "hono"
-            ]
+          "path": "packages/templates/express/src/routes/dodopayments/route.ts",
+          "content": "Main DodoPayments router for Express.js",
+          "type": "template",
+          "target": "routes/dodopayments/route.ts"
         },
         {
-            "name": "hono-stripe",
-            "description": "Stripe template for Hono",
-            "framework": "hono",
-            "files": [
-                {
-                    "path": "packages/templates/hono/src/lib/stripe.ts",
-                    "content": "Stripe library for Hono",
-                    "type": "template",
-                    "target": "lib/stripe.ts"
-                },
-                {
-                    "path": "packages/templates/hono/src/routes/stripe/route.ts",
-                    "content": "Main Stripe router for Hono",
-                    "type": "template",
-                    "target": "routes/route.ts"
-                },
-                {
-                    "path": "packages/templates/hono/src/routes/stripe/checkout.ts",
-                    "content": "Checkout routes for Hono",
-                    "type": "template",
-                    "target": "routes/stripe/checkout.ts"
-                },
-                {
-                    "path": "packages/templates/hono/src/routes/stripe/customer.ts",
-                    "content": "Customer management routes for Hono",
-                    "type": "template",
-                    "target": "routes/stripe/customer.ts"
-                },
-                {
-                    "path": "packages/templates/hono/src/routes/stripe/payments.ts",
-                    "content": "Payment routes for Hono",
-                    "type": "template",
-                    "target": "routes/stripe/payments.ts"
-                },
-                {
-                    "path": "packages/templates/hono/src/routes/stripe/products.ts",
-                    "content": "Product management routes for Hono",
-                    "type": "template",
-                    "target": "routes/stripe/products.ts"
-                },
-                {
-                    "path": "packages/templates/hono/src/routes/stripe/subscriptions.ts",
-                    "content": "Subscription management routes for Hono",
-                    "type": "template",
-                    "target": "routes/stripe/subscriptions.ts"
-                },
-                {
-                    "path": "packages/templates/hono/src/routes/stripe/webhook.ts",
-                    "content": "Webhook handling routes for Hono",
-                    "type": "template",
-                    "target": "routes/stripe/webhook.ts"
-                },
-                {
-                    "path": "packages/templates/hono/.env.example",
-                    "content": "Stripe .env.example for Hono",
-                    "type": "template",
-                    "target": ".env.example"
-                }
-            ],
-            "dependencies": [
-                "stripe",
-                "standardwebhooks",
-                "zod",
-                "hono",
-                "@hono/zod-validator"
-            ]
+          "path": "packages/templates/express/src/routes/dodopayments/checkout.ts",
+          "content": "Checkout routes for Express.js",
+          "type": "template",
+          "target": "routes/dodopayments/checkout.ts"
+        },
+        {
+          "path": "packages/templates/express/src/routes/dodopayments/customer.ts",
+          "content": "Customer management routes for Express.js",
+          "type": "template",
+          "target": "routes/dodopayments/customer.ts"
+        },
+        {
+          "path": "packages/templates/express/src/routes/dodopayments/payments.ts",
+          "content": "Payment routes for Express.js",
+          "type": "template",
+          "target": "routes/dodopayments/payments.ts"
+        },
+        {
+          "path": "packages/templates/express/src/routes/dodopayments/products.ts",
+          "content": "Product management routes for Express.js",
+          "type": "template",
+          "target": "routes/dodopayments/products.ts"
+        },
+        {
+          "path": "packages/templates/express/src/routes/dodopayments/subscriptions.ts",
+          "content": "Subscription management routes for Express.js",
+          "type": "template",
+          "target": "routes/dodopayments/subscriptions.ts"
+        },
+        {
+          "path": "packages/templates/express/src/routes/dodopayments/webhook.ts",
+          "content": "Webhook handling routes for Express.js",
+          "type": "template",
+          "target": "routes/dodopayments/webhook.ts"
+        },
+        {
+          "path": "packages/templates/express/.env.example",
+          "content": "DodoPayments .env.example for Express.js",
+          "type": "template",
+          "target": ".env.example"
+        }
+      ],
+      "dependencies": [
+        "dodopayments",
+        "standardwebhooks",
+        "zod",
+        "express",
+        "@types/express"
+      ]
+    },
+    {
+      "name": "express-stripe",
+      "description": "Stripe template for Express.js",
+      "framework": "express",
+      "files": [
+        {
+          "path": "packages/templates/express/src/lib/stripe.ts",
+          "content": "Stripe client setup for Express.js",
+          "type": "template",
+          "target": "lib/stripe.ts"
+        },
+        {
+          "path": "packages/templates/express/src/routes/stripe/route.ts",
+          "content": "Main DodoPayments router for Express.js",
+          "type": "template",
+          "target": "routes/stripe/route.ts"
         },
 
-
         {
-            "name": "nextjs-stripe",
-            "description": "Stripe template for NextJS",
-            "framework": "nextjs",
-            "files": [
-                {
-                    "path": "packages/templates/nextjs/lib/stripe.ts",
-                    "content": "Stripe library for NextJS",
-                    "type": "template",
-                    "target": "lib/stripe.ts"
-                },
-                {
-                    "path": "packages/templates/nextjs/api-routes/(stripe)/*",
-                    "content": "Stripe API routes for NextJS",
-                    "type": "template",
-                    "target": "app/api/(stripe)/*"
-                },
-                {
-                    "path": "packages/templates/nextjs/.env.example",
-                    "content": "Stripe .env.example for NextJS",
-                    "type": "template",
-                    "target": ".env.example"
-                }
-            ],
-            "dependencies": [
-                "stripe",
-                "react",
-                "zod"
-            ]
-       }
-
-
-
-    ]
+          "path": "packages/templates/express/src/routes/stripe/checkout.ts",
+          "content": "Stripe checkout routes",
+          "type": "template",
+          "target": "routes/stripe/checkout.ts"
+        },
+        {
+          "path": "packages/templates/express/src/routes/stripe/customer.ts",
+          "content": "Stripe customer routes",
+          "type": "template",
+          "target": "routes/stripe/customer.ts"
+        },
+        {
+          "path": "packages/templates/express/src/routes/stripe/payments.ts",
+          "content": "Stripe payments routes",
+          "type": "template",
+          "target": "routes/stripe/payments.ts"
+        },
+        {
+          "path": "packages/templates/express/src/routes/stripe/products.ts",
+          "content": "Stripe product routes",
+          "type": "template",
+          "target": "routes/stripe/products.ts"
+        },
+        {
+          "path": "packages/templates/express/src/routes/stripe/subscriptions.ts",
+          "content": "Stripe checkout routes",
+          "type": "template",
+          "target": "routes/stripe/subscriptions.ts"
+        },
+        {
+          "path": "packages/templates/express/src/routes/stripe/webhook.ts",
+          "content": "Webhook handling routes for Express.js",
+          "type": "template",
+          "target": "routes/stripe/webhook.ts"
+        },
+        {
+          "path": "packages/templates/express/.env.example",
+          "content": "Stripe .env.example for Express.js",
+          "type": "template",
+          "target": ".env.example"
+        }
+      ],
+      "dependencies": ["stripe", "express", "zod", "@types/express"]
+    },
+    {
+      "name": "react-dodopayments",
+      "description": "DodoPayments template for React.js",
+      "framework": "react",
+      "files": [
+        {
+          "path": "packages/templates/react/lib/dodopayments.ts",
+          "content": "DodoPayments library for React.js",
+          "type": "template",
+          "target": "lib/dodopayments.ts"
+        },
+        {
+          "path": "packages/templates/react/hooks/useBilling.ts",
+          "content": "Custom React hook for managing DodoPayments billing flows",
+          "type": "template",
+          "target": "hooks/useBilling.ts"
+        },
+        {
+          "path": "packages/templates/react/.env.example",
+          "content": "DodoPayments .env.example for React.js",
+          "type": "template",
+          "target": ".env.example"
+        }
+      ],
+      "dependencies": ["dodopayments", "react"]
+    },
+    {
+      "name": "fastify-dodopayments",
+      "description": "DodoPayments template for Fastify",
+      "framework": "fastify",
+      "files": [
+        {
+          "path": "packages/templates/fastify/src/lib/dodopayments.ts",
+          "content": "DodoPayments library for Fastify",
+          "type": "template",
+          "target": "lib/dodopayments.ts"
+        },
+        {
+          "path": "packages/templates/fastify/src/routes/dodopayments/route.ts",
+          "content": "Main DodoPayments routes for Fastify",
+          "type": "template",
+          "target": "routes/dodopayments/route.ts"
+        },
+        {
+          "path": "packages/templates/fastify/src/routes/dodopayments/checkout.ts",
+          "content": "Checkout routes for Fastify",
+          "type": "template",
+          "target": "routes/dodopayments/checkout.ts"
+        },
+        {
+          "path": "packages/templates/fastify/src/routes/dodopayments/customer.ts",
+          "content": "Customer management routes for Fastify",
+          "type": "template",
+          "target": "routes/dodopayments/customer.ts"
+        },
+        {
+          "path": "packages/templates/fastify/src/routes/dodopayments/payments.ts",
+          "content": "Payment routes for Fastify",
+          "type": "template",
+          "target": "routes/dodopayments/payments.ts"
+        },
+        {
+          "path": "packages/templates/fastify/src/routes/dodopayments/products.ts",
+          "content": "Product management routes for Fastify",
+          "type": "template",
+          "target": "routes/dodopayments/products.ts"
+        },
+        {
+          "path": "packages/templates/fastify/src/routes/dodopayments/subscriptions.ts",
+          "content": "Subscription management routes for Fastify",
+          "type": "template",
+          "target": "routes/dodopayments/subscriptions.ts"
+        },
+        {
+          "path": "packages/templates/fastify/src/routes/dodopayments/webhook.ts",
+          "content": "Webhook handling routes for Fastify",
+          "type": "template",
+          "target": "routes/dodopayments/webhook.ts"
+        },
+        {
+          "path": "packages/templates/fastify/.env.example",
+          "content": "DodoPayments .env.example for Fastify",
+          "type": "template",
+          "target": ".env.example"
+        }
+      ],
+      "dependencies": [
+        "dodopayments",
+        "standardwebhooks",
+        "zod",
+        "fastify",
+        "fastify-raw-body"
+      ]
+    },
+    {
+      "name": "hono-dodopayments",
+      "description": "DodoPayments template for Hono",
+      "framework": "hono",
+      "files": [
+        {
+          "path": "packages/templates/hono/src/lib/dodopayments.ts",
+          "content": "DodoPayments library for Hono",
+          "type": "template",
+          "target": "lib/dodopayments.ts"
+        },
+        {
+          "path": "packages/templates/hono/src/routes/route.ts",
+          "content": "Main DodoPayments router for Hono",
+          "type": "template",
+          "target": "routes/route.ts"
+        },
+        {
+          "path": "packages/templates/hono/src/routes/dodopayments/checkout.ts",
+          "content": "Checkout routes for Hono",
+          "type": "template",
+          "target": "routes/dodopayments/checkout.ts"
+        },
+        {
+          "path": "packages/templates/hono/src/routes/dodopayments/customer.ts",
+          "content": "Customer management routes for Hono",
+          "type": "template",
+          "target": "routes/dodopayments/customer.ts"
+        },
+        {
+          "path": "packages/templates/hono/src/routes/dodopayments/payments.ts",
+          "content": "Payment routes for Hono",
+          "type": "template",
+          "target": "routes/dodopayments/payments.ts"
+        },
+        {
+          "path": "packages/templates/hono/src/routes/dodopayments/products.ts",
+          "content": "Product management routes for Hono",
+          "type": "template",
+          "target": "routes/dodopayments/products.ts"
+        },
+        {
+          "path": "packages/templates/hono/src/routes/dodopayments/subscriptions.ts",
+          "content": "Subscription management routes for Hono",
+          "type": "template",
+          "target": "routes/dodopayments/subscriptions.ts"
+        },
+        {
+          "path": "packages/templates/hono/src/routes/dodopayments/webhook.ts",
+          "content": "Webhook handling routes for Hono",
+          "type": "template",
+          "target": "routes/dodopayments/webhook.ts"
+        },
+        {
+          "path": "packages/templates/hono/.env.example",
+          "content": "DodoPayments .env.example for Hono",
+          "type": "template",
+          "target": ".env.example"
+        }
+      ],
+      "dependencies": ["dodopayments", "standardwebhooks", "zod", "hono"]
+    },
+    {
+      "name": "hono-stripe",
+      "description": "Stripe template for Hono",
+      "framework": "hono",
+      "files": [
+        {
+          "path": "packages/templates/hono/src/lib/stripe.ts",
+          "content": "Stripe library for Hono",
+          "type": "template",
+          "target": "lib/stripe.ts"
+        },
+        {
+          "path": "packages/templates/hono/src/routes/stripe/route.ts",
+          "content": "Main Stripe router for Hono",
+          "type": "template",
+          "target": "routes/route.ts"
+        },
+        {
+          "path": "packages/templates/hono/src/routes/stripe/checkout.ts",
+          "content": "Checkout routes for Hono",
+          "type": "template",
+          "target": "routes/stripe/checkout.ts"
+        },
+        {
+          "path": "packages/templates/hono/src/routes/stripe/customer.ts",
+          "content": "Customer management routes for Hono",
+          "type": "template",
+          "target": "routes/stripe/customer.ts"
+        },
+        {
+          "path": "packages/templates/hono/src/routes/stripe/payments.ts",
+          "content": "Payment routes for Hono",
+          "type": "template",
+          "target": "routes/stripe/payments.ts"
+        },
+        {
+          "path": "packages/templates/hono/src/routes/stripe/products.ts",
+          "content": "Product management routes for Hono",
+          "type": "template",
+          "target": "routes/stripe/products.ts"
+        },
+        {
+          "path": "packages/templates/hono/src/routes/stripe/subscriptions.ts",
+          "content": "Subscription management routes for Hono",
+          "type": "template",
+          "target": "routes/stripe/subscriptions.ts"
+        },
+        {
+          "path": "packages/templates/hono/src/routes/stripe/webhook.ts",
+          "content": "Webhook handling routes for Hono",
+          "type": "template",
+          "target": "routes/stripe/webhook.ts"
+        },
+        {
+          "path": "packages/templates/hono/.env.example",
+          "content": "Stripe .env.example for Hono",
+          "type": "template",
+          "target": ".env.example"
+        }
+      ],
+      "dependencies": [
+        "stripe",
+        "standardwebhooks",
+        "zod",
+        "hono",
+        "@hono/zod-validator"
+      ]
+    },
+    {
+      "name": "react-stripe",
+      "description": "Stripe template for React.js",
+      "framework": "react",
+      "files": [
+        {
+          "path": "packages/templates/react/lib/stripe.ts",
+          "content": "Stripe library for React.js",
+          "type": "template",
+          "target": "lib/stripe.ts"
+        },
+        {
+          "path": "packages/templates/react/hooks/stripe/useBilling.ts",
+          "content": "Custom React hook for managing Stripe billing flows",
+          "type": "template",
+          "target": "hooks/stripe/useBilling.ts"
+        },
+        {
+          "path": "packages/templates/react/.env.example",
+          "content": "Stripe .env.example for React.js",
+          "type": "template",
+          "target": ".env.example"
+        }
+      ],
+      "dependencies": ["stripe", "react"]
+    }
+  ]
 }


### PR DESCRIPTION
fixes #208 

**Summary**
Add Stripe support for React templates, mirroring the existing DodoPayments structure. This introduces a type-safe client library and React hook that call backend Stripe endpoints via a configurable baseUrl, enabling consistent integration across projects without exposing Stripe keys on the client.

**Changes**

- Add packages/templates/react/lib/stripe.ts: type-safe fetch-layer for Stripe resources (products, customer, subscriptions, payments) and checkout creation.

- Add packages/templates/react/hooks/stripe/useBilling.ts: React hook with loading/error state and helpers (fetchProducts, fetchCustomer, createCheckout, etc.).

- Update packages/templates/registry.json: register new react-stripe template entries (lib + hook) for CLI consumption.

- Align API contract with server templates (Express/Fastify/Hono): expects routes like /products, /product, /customer, /customer/subscriptions, /customer/payments, POST /customer, PUT /customer, POST /checkout.

Ensure client uses only baseUrl (no client-side Stripe keys); server continues to use STRIPE_SECRET_KEY and webhook secret

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Stripe billing support in React templates: a billing hook and client utilities for products, customers, subscriptions, payments, and checkout flows.
  - Configurable base URL with sensible defaults for local development.

- **Refactor**
  - Registry public declarations reorganized into a nested, path-aware layout for clearer component exports.
  - Shared Stripe client utilities standardize API calls and error handling.

- **Chores**
  - Formatting and style cleanups across templates; no behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->