### PR TITLE
chore: add bun installation support to all component docs

### DIFF
--- a/content/docs/components/billing-setting/index.mdx
+++ b/content/docs/components/billing-setting/index.mdx
@@ -20,7 +20,7 @@ import BillingSettingsDemo from "src/components/billing-settings-demo.tsx"
 ### Installation
 <Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
     <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
-        <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+        <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
             <Tab value="npx">
                 ```bash
                 npx shadcn@latest add @billingsdk/billing-settings
@@ -36,10 +36,15 @@ import BillingSettingsDemo from "src/components/billing-settings-demo.tsx"
                 yarn dlx shadcn@latest add @billingsdk/billing-settings
                 ```
             </Tab>
+            <Tab value="bun">
+                ```bash
+                bunx shadcn@latest add @billingsdk/billing-settings
+                ```
+            </Tab>
         </Tabs>
     </Tab>
     <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
-        <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+        <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
             <Tab value="npx">
                 ```bash
                 npx @billingsdk/cli add billing-settings
@@ -53,6 +58,11 @@ import BillingSettingsDemo from "src/components/billing-settings-demo.tsx"
             <Tab value="yarn">
                 ```bash
                 yarn dlx @billingsdk/cli add billing-settings
+                ```
+            </Tab>
+            <Tab value="bun">
+                ```bash
+                bunx @billingsdk/cli add billing-settings
                 ```
             </Tab>
         </Tabs>

--- a/content/docs/components/cancel-subscription/cancel-subscription-card-two.mdx
+++ b/content/docs/components/cancel-subscription/cancel-subscription-card-two.mdx
@@ -19,7 +19,7 @@ description: The Cancel Subscription Card Two component provides an improved, us
 
 <Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
   <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
       <Tab value="npx">
         ```bash
         npx shadcn@latest add @billingsdk/cancel-subscription-card-two
@@ -35,10 +35,15 @@ description: The Cancel Subscription Card Two component provides an improved, us
         yarn dlx shadcn@latest add @billingsdk/cancel-subscription-card-two
         ```
       </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/cancel-subscription-card-two
+        ```
+      </Tab>
     </Tabs>
   </Tab>
   <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
       <Tab value="npx">
         ```bash
         npx @billingsdk/cli add cancel-subscription-card-two
@@ -52,6 +57,11 @@ description: The Cancel Subscription Card Two component provides an improved, us
       <Tab value="yarn">
         ```bash
         yarn dlx @billingsdk/cli add cancel-subscription-card-two
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add cancel-subscription-card-two
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/cancel-subscription/cancel-subscription-card.mdx
+++ b/content/docs/components/cancel-subscription/cancel-subscription-card.mdx
@@ -20,7 +20,7 @@ description: The Cancel Subscription Card component provides a comprehensive and
 
 <Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
   <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
       <Tab value="npx">
         ```bash
         npx shadcn@latest add @billingsdk/cancel-subscription-card
@@ -36,10 +36,15 @@ description: The Cancel Subscription Card component provides a comprehensive and
         yarn dlx shadcn@latest add @billingsdk/cancel-subscription-card
         ```
       </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/cancel-subscription-card
+        ```
+      </Tab>
     </Tabs>
   </Tab>
   <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
       <Tab value="npx">
         ```bash
         npx @billingsdk/cli add cancel-subscription-card
@@ -53,6 +58,11 @@ description: The Cancel Subscription Card component provides a comprehensive and
       <Tab value="yarn">
         ```bash
         yarn dlx @billingsdk/cli add cancel-subscription-card
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add cancel-subscription-card
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/cancel-subscription/cancel-subscription-dialog.mdx
+++ b/content/docs/components/cancel-subscription/cancel-subscription-dialog.mdx
@@ -20,7 +20,7 @@ description: The Cancel Subscription Dialog component provides a comprehensive a
 
 <Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
   <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
       <Tab value="npx">
         ```bash
         npx shadcn@latest add @billingsdk/cancel-subscription-dialog
@@ -36,10 +36,15 @@ description: The Cancel Subscription Dialog component provides a comprehensive a
         yarn dlx shadcn@latest add @billingsdk/cancel-subscription-dialog
         ```
       </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/cancel-subscription-dialog
+        ```
+      </Tab>
     </Tabs>
   </Tab>
   <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
       <Tab value="npx">
         ```bash
         npx @billingsdk/cli add cancel-subscription-dialog
@@ -53,6 +58,11 @@ description: The Cancel Subscription Dialog component provides a comprehensive a
       <Tab value="yarn">
         ```bash
         yarn dlx @billingsdk/cli add cancel-subscription-dialog
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add cancel-subscription-dialog
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/coupon/index.mdx
+++ b/content/docs/components/coupon/index.mdx
@@ -19,7 +19,7 @@ description: The Coupon Generator component provides an interactive interface fo
 
 <Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
   <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
       <Tab value="npx">
         ```bash
         npx shadcn@latest add @billingsdk/coupon
@@ -32,13 +32,18 @@ description: The Coupon Generator component provides an interactive interface fo
       </Tab>
       <Tab value="yarn">
         ```bash
-        npx shadcn@latest add @billingsdk/coupon
+        yarn dlx shadcn@latest add @billingsdk/coupon
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/coupon
         ```
       </Tab>
     </Tabs>
   </Tab>
   <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
       <Tab value="npx">
         ```bash
         npx @billingsdk/cli add coupon
@@ -51,7 +56,12 @@ description: The Coupon Generator component provides an interactive interface fo
       </Tab>
       <Tab value="yarn">
         ```bash
-        npx @billingsdk/cli add coupon
+        yarn dlx @billingsdk/cli add coupon
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add coupon
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/invoice-history/index.mdx
+++ b/content/docs/components/invoice-history/index.mdx
@@ -19,7 +19,7 @@ description: Read-only table for displaying past invoices and receipts with stat
 
 <Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
   <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
       <Tab value="npx">
         ```bash
         npx shadcn@latest add @billingsdk/invoice-history
@@ -35,10 +35,15 @@ description: Read-only table for displaying past invoices and receipts with stat
         yarn dlx shadcn@latest add @billingsdk/invoice-history
         ```
       </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/invoice-history
+        ```
+      </Tab>
     </Tabs>
   </Tab>
   <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
       <Tab value="npx">
         ```bash
         npx @billingsdk/cli add invoice-history
@@ -52,6 +57,11 @@ description: Read-only table for displaying past invoices and receipts with stat
       <Tab value="yarn">
         ```bash
         yarn dlx @billingsdk/cli add invoice-history
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add invoice-history
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/payment-details/index.mdx
+++ b/content/docs/components/payment-details/index.mdx
@@ -21,7 +21,7 @@ Choose your preferred installation method:
 
 <Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
   <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
       <Tab value="npx">
         ```bash
         npx shadcn@latest add @billingsdk/payment-details
@@ -37,10 +37,15 @@ Choose your preferred installation method:
         yarn dlx shadcn@latest add @billingsdk/payment-details
         ```
       </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/payment-details
+        ```
+      </Tab>
     </Tabs>
   </Tab>
   <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
       <Tab value="npx">
         ```bash
         npx @billingsdk/cli add payment-details
@@ -54,6 +59,11 @@ Choose your preferred installation method:
       <Tab value="yarn">
         ```bash
         yarn dlx @billingsdk/cli add payment-details
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add payment-details
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/payment-method-selector/index.mdx
+++ b/content/docs/components/payment-method-selector/index.mdx
@@ -22,7 +22,7 @@ description: Interactive selector for Cards, Digital Wallets, UPI (India), and B
 
 <Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
   <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
       <Tab value="npx">
         ```bash
         npx shadcn@latest add @billingsdk/payment-method-selector
@@ -38,10 +38,15 @@ description: Interactive selector for Cards, Digital Wallets, UPI (India), and B
         yarn dlx shadcn@latest add @billingsdk/payment-method-selector
         ```
       </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/payment-method-selector
+        ```
+      </Tab>
     </Tabs>
   </Tab>
   <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
       <Tab value="npx">
         ```bash
         npx @billingsdk/cli add payment-method-selector
@@ -55,6 +60,11 @@ description: Interactive selector for Cards, Digital Wallets, UPI (India), and B
       <Tab value="yarn">
         ```bash
         yarn dlx @billingsdk/cli add payment-method-selector
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add payment-method-selector
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/payment-success-dialog/index.mdx
+++ b/content/docs/components/payment-success-dialog/index.mdx
@@ -20,7 +20,7 @@ description: A confirmation dialog that celebrates a successful payment with the
 
 <Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
   <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
       <Tab value="npx">
         ```bash
         npx shadcn@latest add @billingsdk/payment-success-dialog
@@ -36,10 +36,15 @@ description: A confirmation dialog that celebrates a successful payment with the
         yarn dlx shadcn@latest add @billingsdk/payment-success-dialog
         ```
       </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/payment-success-dialog
+        ```
+      </Tab>
     </Tabs>
   </Tab>
   <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
       <Tab value="npx">
         ```bash
         npx @billingsdk/cli add payment-success-dialog
@@ -53,6 +58,11 @@ description: A confirmation dialog that celebrates a successful payment with the
       <Tab value="yarn">
         ```bash
         yarn dlx @billingsdk/cli add payment-success-dialog
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add payment-success-dialog
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/pricing-table/pricing-table-four.mdx
+++ b/content/docs/components/pricing-table/pricing-table-four.mdx
@@ -17,21 +17,54 @@ description: The Pricing Table Four component provides a modern gradient design 
 
 ## Installation
 
-<Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
-  <Tab value="npx">
-    ```bash
-    npx shadcn@latest add @billingsdk/pricing-table-four
-    ```
+<Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
+  <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
+      <Tab value="npx">
+        ```bash
+        npx shadcn@latest add @billingsdk/pricing-table-four
+        ```
+      </Tab>
+      <Tab value="pnpm">
+        ```bash
+        pnpm dlx shadcn@latest add @billingsdk/pricing-table-four
+        ```
+      </Tab>
+      <Tab value="yarn">
+        ```bash
+        yarn dlx shadcn@latest add @billingsdk/pricing-table-four
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/pricing-table-four
+        ```
+      </Tab>
+    </Tabs>
   </Tab>
-  <Tab value="pnpm">
-    ```bash
-    pnpm dlx shadcn@latest add @billingsdk/pricing-table-four
-    ```
-  </Tab>
-  <Tab value="yarn">
-    ```bash
-    yarn dlx shadcn@latest add @billingsdk/pricing-table-four
-    ```
+  <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+      <Tab value="npx">
+        ```bash
+        npx @billingsdk/cli add pricing-table-four
+        ```
+      </Tab>
+      <Tab value="pnpm">
+        ```bash
+        pnpm dlx @billingsdk/cli add pricing-table-four
+        ```
+      </Tab>
+      <Tab value="yarn">
+        ```bash
+        yarn dlx @billingsdk/cli add pricing-table-four
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add pricing-table-four
+        ```
+      </Tab>
+    </Tabs>
   </Tab>
 </Tabs>
 

--- a/content/docs/components/pricing-table/pricing-table-seven.mdx
+++ b/content/docs/components/pricing-table/pricing-table-seven.mdx
@@ -17,21 +17,54 @@ description: The Pricing Table Seven component provides a Modern pricing design 
 
 ## Installation
 
-<Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
-  <Tab value="npx">
-    ```bash
-    npx shadcn@latest add @billingsdk/pricing-table-seven
-    ```
+<Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
+  <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
+      <Tab value="npx">
+        ```bash
+        npx shadcn@latest add @billingsdk/pricing-table-seven
+        ```
+      </Tab>
+      <Tab value="pnpm">
+        ```bash
+        pnpm dlx shadcn@latest add @billingsdk/pricing-table-seven
+        ```
+      </Tab>
+      <Tab value="yarn">
+        ```bash
+        yarn dlx shadcn@latest add @billingsdk/pricing-table-seven
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/pricing-table-seven
+        ```
+      </Tab>
+    </Tabs>
   </Tab>
-  <Tab value="pnpm">
-    ```bash
-    pnpm dlx shadcn@latest add @billingsdk/pricing-table-seven
-    ```
-  </Tab>
-  <Tab value="yarn">
-    ```bash
-    yarn dlx shadcn@latest add @billingsdk/pricing-table-seven
-    ```
+  <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+      <Tab value="npx">
+        ```bash
+        npx @billingsdk/cli add pricing-table-seven
+        ```
+      </Tab>
+      <Tab value="pnpm">
+        ```bash
+        pnpm dlx @billingsdk/cli add pricing-table-seven
+        ```
+      </Tab>
+      <Tab value="yarn">
+        ```bash
+        yarn dlx @billingsdk/cli add pricing-table-seven
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add pricing-table-seven
+        ```
+      </Tab>
+    </Tabs>
   </Tab>
 </Tabs>
 

--- a/content/docs/components/pricing-table/pricing-table-six.mdx
+++ b/content/docs/components/pricing-table/pricing-table-six.mdx
@@ -17,21 +17,54 @@ description: The Pricing Table Six component provides a modern gradient design f
 
 ## Installation
 
-<Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
-  <Tab value="npx">
-    ```bash
-    npx shadcn@latest add @billingsdk/pricing-table-six
-    ```
+<Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
+  <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
+      <Tab value="npx">
+        ```bash
+        npx shadcn@latest add @billingsdk/pricing-table-six
+        ```
+      </Tab>
+      <Tab value="pnpm">
+        ```bash
+        pnpm dlx shadcn@latest add @billingsdk/pricing-table-six
+        ```
+      </Tab>
+      <Tab value="yarn">
+        ```bash
+        yarn dlx shadcn@latest add @billingsdk/pricing-table-six
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/pricing-table-six
+        ```
+      </Tab>
+    </Tabs>
   </Tab>
-  <Tab value="pnpm">
-    ```bash
-    pnpm dlx shadcn@latest add @billingsdk/pricing-table-six
-    ```
-  </Tab>
-  <Tab value="yarn">
-    ```bash
-    yarn dlx shadcn@latest add @billingsdk/pricing-table-six
-    ```
+  <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+      <Tab value="npx">
+        ```bash
+        npx @billingsdk/cli add pricing-table-six
+        ```
+      </Tab>
+      <Tab value="pnpm">
+        ```bash
+        pnpm dlx @billingsdk/cli add pricing-table-six
+        ```
+      </Tab>
+      <Tab value="yarn">
+        ```bash
+        yarn dlx @billingsdk/cli add pricing-table-six
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add pricing-table-six
+        ```
+      </Tab>
+    </Tabs>
   </Tab>
 </Tabs>
 

--- a/content/docs/components/pricing-table/pricing-table-three.mdx
+++ b/content/docs/components/pricing-table/pricing-table-three.mdx
@@ -19,7 +19,7 @@ description: The Pricing Table Three component provides a third design option fo
 
 <Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
   <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
       <Tab value="npx">
         ```bash
         npx shadcn@latest add @billingsdk/pricing-table-three
@@ -35,10 +35,15 @@ description: The Pricing Table Three component provides a third design option fo
         yarn dlx shadcn@latest add @billingsdk/pricing-table-three
         ```
       </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/pricing-table-three
+        ```
+      </Tab>
     </Tabs>
   </Tab>
   <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
       <Tab value="npx">
         ```bash
         npx @billingsdk/cli add pricing-table-three
@@ -52,6 +57,11 @@ description: The Pricing Table Three component provides a third design option fo
       <Tab value="yarn">
         ```bash
         yarn dlx @billingsdk/cli add pricing-table-three
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add pricing-table-three
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/pricing-table/pricing-table-two.mdx
+++ b/content/docs/components/pricing-table/pricing-table-two.mdx
@@ -38,7 +38,7 @@ description: The Pricing Table Two component offers an alternative design approa
 
 <Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
   <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
       <Tab value="npx">
         ```bash
         npx shadcn@latest add @billingsdk/pricing-table-two
@@ -54,10 +54,15 @@ description: The Pricing Table Two component offers an alternative design approa
         yarn dlx shadcn@latest add @billingsdk/pricing-table-two
         ```
       </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/pricing-table-two
+        ```
+      </Tab>
     </Tabs>
   </Tab>
   <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
       <Tab value="npx">
         ```bash
         npx @billingsdk/cli add pricing-table-two
@@ -71,6 +76,11 @@ description: The Pricing Table Two component offers an alternative design approa
       <Tab value="yarn">
         ```bash
         yarn dlx @billingsdk/cli add pricing-table-two
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add pricing-table-two
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/update-plan/update-plan-card.mdx
+++ b/content/docs/components/update-plan/update-plan-card.mdx
@@ -20,7 +20,7 @@ description: The Update Plan Card component provides a compact, card-based inter
 
 <Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
   <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
       <Tab value="npx">
         ```bash
         npx shadcn@latest add @billingsdk/update-plan-card
@@ -36,10 +36,15 @@ description: The Update Plan Card component provides a compact, card-based inter
         yarn dlx shadcn@latest add @billingsdk/update-plan-card
         ```
       </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/update-plan-card
+        ```
+      </Tab>
     </Tabs>
   </Tab>
   <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
       <Tab value="npx">
         ```bash
         npx @billingsdk/cli add update-plan-card
@@ -53,6 +58,11 @@ description: The Update Plan Card component provides a compact, card-based inter
       <Tab value="yarn">
         ```bash
         yarn dlx @billingsdk/cli add update-plan-card
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add update-plan-card
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/update-plan/update-plan-dialog.mdx
+++ b/content/docs/components/update-plan/update-plan-dialog.mdx
@@ -20,7 +20,7 @@ description: The Update Plan Dialog component provides an interactive interface 
 
 <Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
   <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
       <Tab value="npx">
         ```bash
         npx shadcn@latest add @billingsdk/update-plan-dialog
@@ -36,10 +36,15 @@ description: The Update Plan Dialog component provides an interactive interface 
         yarn dlx shadcn@latest add @billingsdk/update-plan-dialog
         ```
       </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/update-plan-dialog
+        ```
+      </Tab>
     </Tabs>
   </Tab>
   <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
       <Tab value="npx">
         ```bash
         npx @billingsdk/cli add update-plan-dialog
@@ -53,6 +58,11 @@ description: The Update Plan Dialog component provides an interactive interface 
       <Tab value="yarn">
         ```bash
         yarn dlx @billingsdk/cli add update-plan-dialog
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add update-plan-dialog
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/usage-meter/usage-meter-linear.mdx
+++ b/content/docs/components/usage-meter/usage-meter-linear.mdx
@@ -23,7 +23,7 @@ You can change the progress color of the usage meter to `default` or `usage`.
 
 <Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
   <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
       <Tab value="npx">
         ```bash
         npx shadcn@latest add @billingsdk/usage-meter-linear
@@ -39,10 +39,15 @@ You can change the progress color of the usage meter to `default` or `usage`.
         yarn dlx shadcn@latest add @billingsdk/usage-meter-linear
         ```
       </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/usage-meter-linear
+        ```
+      </Tab>
     </Tabs>
   </Tab>
   <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
       <Tab value="npx">
         ```bash
         npx @billingsdk/cli add usage-meter-linear
@@ -56,6 +61,11 @@ You can change the progress color of the usage meter to `default` or `usage`.
       <Tab value="yarn">
         ```bash
         yarn dlx @billingsdk/cli add usage-meter-linear
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add usage-meter-linear
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/usage-table/index.mdx
+++ b/content/docs/components/usage-table/index.mdx
@@ -19,7 +19,7 @@ description: Per-model LLM usage with token counts, cache reads, and API cost.
 
 <Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
   <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
       <Tab value="npx">
         ```bash
         npx shadcn@latest add @billingsdk/usage-table
@@ -35,10 +35,15 @@ description: Per-model LLM usage with token counts, cache reads, and API cost.
         yarn dlx shadcn@latest add @billingsdk/usage-table
         ```
       </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/usage-table
+        ```
+      </Tab>
     </Tabs>
   </Tab>
   <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
       <Tab value="npx">
         ```bash
         npx @billingsdk/cli add usage-table
@@ -52,6 +57,11 @@ description: Per-model LLM usage with token counts, cache reads, and API cost.
       <Tab value="yarn">
         ```bash
         yarn dlx @billingsdk/cli add usage-table
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add usage-table
         ```
       </Tab>
     </Tabs>


### PR DESCRIPTION
### Summary
Add bun package manager support to component  installation documentation. This ensures all  components have consistent installation instructions across npm, pnpm, yarn, and bun package managers.

### Changes
  - Added bun installation tabs to 23 component  documentation files that were missing this option
  - Fixed incorrect yarn commands in coupon component (was using npx instead of yarn dlx)
  - Standardized installation tab structure across all  components to include shadcn and billingSDK CLI options
  - Updated both shadcn (bunx shadcn@latest add) and billingSDK (bunx @billingsdk/cli add) installation  commands

### How to Test
Steps to validate locally:
1. npm ci
2. npm run typecheck
3. npm run build
4. Navigate to any component documentation page and verify all 4 package manager tabs (npx, pnpm, yarn, bun) are present

### Checklist
- [x] Title is clear and descriptive
- [x] Related issue linked #247 
- [x] Tests or manual verification steps included
- [x] CI passes (typecheck & build)
- [x] Docs updated (if needed)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added Bun installation option (bunx) alongside npx/pnpm/yarn across component docs, including billing settings, cancel subscription variants, coupon, invoice history, payment details, payment method selector, payment success dialog, pricing tables (two/three/four/six/seven), update plan (card/dialog), usage meter (linear), and usage table.
  - Reworked installation sections for pricing tables four/six/seven into dual tabs: shadcn and billingSDK, each with nested package manager tabs (npx/pnpm/yarn/bun).
  - No changes to runtime behavior or APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->