### PR TITLE
chore(docs): add bun installation option to all component docs

### DIFF
--- a/content/docs/components/billing-setting/index.mdx
+++ b/content/docs/components/billing-setting/index.mdx
@@ -20,7 +20,7 @@ import BillingSettingsDemo from "src/components/billing-settings-demo.tsx"
 ### Installation
 <Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
     <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
-        <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+        <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
             <Tab value="npx">
                 ```bash
                 npx shadcn@latest add @billingsdk/billing-settings
@@ -36,10 +36,15 @@ import BillingSettingsDemo from "src/components/billing-settings-demo.tsx"
                 yarn dlx shadcn@latest add @billingsdk/billing-settings
                 ```
             </Tab>
+            <Tab value="bun">
+                ```bash
+                bunx shadcn@latest add @billingsdk/billing-settings
+                ```
+            </Tab>
         </Tabs>
     </Tab>
     <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
-        <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+        <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
             <Tab value="npx">
                 ```bash
                 npx @billingsdk/cli add billing-settings
@@ -53,6 +58,11 @@ import BillingSettingsDemo from "src/components/billing-settings-demo.tsx"
             <Tab value="yarn">
                 ```bash
                 yarn dlx @billingsdk/cli add billing-settings
+                ```
+            </Tab>
+            <Tab value="bun">
+                ```bash
+                bunx @billingsdk/cli add billing-settings
                 ```
             </Tab>
         </Tabs>

--- a/content/docs/components/billing-settings-2/index.mdx
+++ b/content/docs/components/billing-settings-2/index.mdx
@@ -25,7 +25,7 @@ description: Variant of Billing Settings matching the inline form layout with sw
 >
 	<Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
 		<Tabs
-			items={['npx', 'pnpm', 'yarn']}
+			items={['npx', 'pnpm', 'yarn', 'bun']}
 			defaultValue="npx"
 			groupId="installation-tabs"
 		>
@@ -44,11 +44,16 @@ description: Variant of Billing Settings matching the inline form layout with sw
 				yarn dlx shadcn@latest add @billingsdk/billing-settings-2 
 				```
 			</Tab>
+			<Tab value="bun">
+				```bash 
+				bunx shadcn@latest add @billingsdk/billing-settings-2 
+				```
+			</Tab>
 		</Tabs>
 	</Tab>
 	<Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
 		<Tabs
-			items={['npx', 'pnpm', 'yarn']}
+			items={['npx', 'pnpm', 'yarn', 'bun']}
 			defaultValue="npx"
 			groupId="billingsdk-cli-tabs"
 		>
@@ -65,6 +70,11 @@ description: Variant of Billing Settings matching the inline form layout with sw
 			<Tab value="yarn">
 				```bash 
 				yarn dlx @billingsdk/cli add billing-settings-2 
+				```
+			</Tab>
+			<Tab value="bun">
+				```bash 
+				bunx @billingsdk/cli add billing-settings-2 
 				```
 			</Tab>
 		</Tabs>

--- a/content/docs/components/billing-summary-card/index.mdx
+++ b/content/docs/components/billing-summary-card/index.mdx
@@ -24,7 +24,7 @@ description: Displays the current subscription plan, pricing information, renewa
 >
 	<Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
 		<Tabs
-			items={['npx', 'pnpm', 'yarn']}
+			items={['npx', 'pnpm', 'yarn', 'bun']}
 			defaultValue="npx"
 			groupId="installation-tabs"
 		>
@@ -43,11 +43,16 @@ description: Displays the current subscription plan, pricing information, renewa
 			yarn dlx shadcn@latest add @billingsdk/billing-summary-card 
 			```
 			</Tab>
+			<Tab value="bun">
+			```bash
+			bunx shadcn@latest add @billingsdk/billing-summary-card 
+			```
+			</Tab>
 		</Tabs>
 	</Tab>
 	<Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
 		<Tabs
-			items={['npx', 'pnpm', 'yarn']}
+			items={['npx', 'pnpm', 'yarn', 'bun']}
 			defaultValue="npx"
 			groupId="billingsdk-cli-tabs"
 		>

--- a/content/docs/components/cancel-subscription/cancel-subscription-card-two.mdx
+++ b/content/docs/components/cancel-subscription/cancel-subscription-card-two.mdx
@@ -19,7 +19,7 @@ description: The Cancel Subscription Card Two component provides an improved, us
 
 <Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
   <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
       <Tab value="npx">
         ```bash
         npx shadcn@latest add @billingsdk/cancel-subscription-card-two
@@ -35,10 +35,15 @@ description: The Cancel Subscription Card Two component provides an improved, us
         yarn dlx shadcn@latest add @billingsdk/cancel-subscription-card-two
         ```
       </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/cancel-subscription-card-two
+        ```
+      </Tab>
     </Tabs>
   </Tab>
   <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
       <Tab value="npx">
         ```bash
         npx @billingsdk/cli add cancel-subscription-card-two
@@ -52,6 +57,11 @@ description: The Cancel Subscription Card Two component provides an improved, us
       <Tab value="yarn">
         ```bash
         yarn dlx @billingsdk/cli add cancel-subscription-card-two
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add cancel-subscription-card-two
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/cancel-subscription/cancel-subscription-card.mdx
+++ b/content/docs/components/cancel-subscription/cancel-subscription-card.mdx
@@ -20,7 +20,7 @@ description: The Cancel Subscription Card component provides a comprehensive and
 
 <Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
   <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
       <Tab value="npx">
         ```bash
         npx shadcn@latest add @billingsdk/cancel-subscription-card
@@ -36,10 +36,15 @@ description: The Cancel Subscription Card component provides a comprehensive and
         yarn dlx shadcn@latest add @billingsdk/cancel-subscription-card
         ```
       </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/cancel-subscription-card
+        ```
+      </Tab>
     </Tabs>
   </Tab>
   <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
       <Tab value="npx">
         ```bash
         npx @billingsdk/cli add cancel-subscription-card
@@ -53,6 +58,11 @@ description: The Cancel Subscription Card component provides a comprehensive and
       <Tab value="yarn">
         ```bash
         yarn dlx @billingsdk/cli add cancel-subscription-card
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add cancel-subscription-card
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/cancel-subscription/cancel-subscription-dialog.mdx
+++ b/content/docs/components/cancel-subscription/cancel-subscription-dialog.mdx
@@ -20,7 +20,7 @@ description: The Cancel Subscription Dialog component provides a comprehensive a
 
 <Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
   <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
       <Tab value="npx">
         ```bash
         npx shadcn@latest add @billingsdk/cancel-subscription-dialog
@@ -36,10 +36,15 @@ description: The Cancel Subscription Dialog component provides a comprehensive a
         yarn dlx shadcn@latest add @billingsdk/cancel-subscription-dialog
         ```
       </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/cancel-subscription-dialog
+        ```
+      </Tab>
     </Tabs>
   </Tab>
   <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
       <Tab value="npx">
         ```bash
         npx @billingsdk/cli add cancel-subscription-dialog
@@ -53,6 +58,11 @@ description: The Cancel Subscription Dialog component provides a comprehensive a
       <Tab value="yarn">
         ```bash
         yarn dlx @billingsdk/cli add cancel-subscription-dialog
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add cancel-subscription-dialog
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/coupon/index.mdx
+++ b/content/docs/components/coupon/index.mdx
@@ -19,7 +19,7 @@ description: The Coupon Generator component provides an interactive interface fo
 
 <Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
   <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
       <Tab value="npx">
         ```bash
         npx shadcn@latest add @billingsdk/coupon
@@ -32,13 +32,18 @@ description: The Coupon Generator component provides an interactive interface fo
       </Tab>
       <Tab value="yarn">
         ```bash
-        npx shadcn@latest add @billingsdk/coupon
+        yarn dlx shadcn@latest add @billingsdk/coupon
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/coupon
         ```
       </Tab>
     </Tabs>
   </Tab>
   <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
       <Tab value="npx">
         ```bash
         npx @billingsdk/cli add coupon
@@ -51,7 +56,12 @@ description: The Coupon Generator component provides an interactive interface fo
       </Tab>
       <Tab value="yarn">
         ```bash
-        npx @billingsdk/cli add coupon
+        yarn dlx @billingsdk/cli add coupon
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add coupon
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/detailed-usage-table/index.mdx
+++ b/content/docs/components/detailed-usage-table/index.mdx
@@ -32,7 +32,7 @@ description: The Detailed Usage Table component provides a comprehensive breakdo
 >
 	<Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
 		<Tabs
-			items={['npx', 'pnpm', 'yarn']}
+			items={['npx', 'pnpm', 'yarn', 'bun']}
 			defaultValue="npx"
 			groupId="installation-tabs"
 		>
@@ -51,11 +51,16 @@ description: The Detailed Usage Table component provides a comprehensive breakdo
 			yarn dlx shadcn@latest add @billingsdk/detailed-usage-table
 			```
 			</Tab>
+			<Tab value="bun">
+			```bash
+			bunx shadcn@latest add @billingsdk/detailed-usage-table
+			```
+			</Tab>
 		</Tabs>
 	</Tab>
 	<Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
 		<Tabs
-			items={['npx', 'pnpm', 'yarn']}
+			items={['npx', 'pnpm', 'yarn', 'bun']}
 			defaultValue="npx"
 			groupId="billingsdk-cli-tabs"
 		>

--- a/content/docs/components/invoice-history/index.mdx
+++ b/content/docs/components/invoice-history/index.mdx
@@ -19,7 +19,7 @@ description: Read-only table for displaying past invoices and receipts with stat
 
 <Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
   <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
       <Tab value="npx">
         ```bash
         npx shadcn@latest add @billingsdk/invoice-history
@@ -35,10 +35,15 @@ description: Read-only table for displaying past invoices and receipts with stat
         yarn dlx shadcn@latest add @billingsdk/invoice-history
         ```
       </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/invoice-history
+        ```
+      </Tab>
     </Tabs>
   </Tab>
   <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
       <Tab value="npx">
         ```bash
         npx @billingsdk/cli add invoice-history
@@ -52,6 +57,11 @@ description: Read-only table for displaying past invoices and receipts with stat
       <Tab value="yarn">
         ```bash
         yarn dlx @billingsdk/cli add invoice-history
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add invoice-history
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/manage-subscription/usage-based-pricing.mdx
+++ b/content/docs/components/manage-subscription/usage-based-pricing.mdx
@@ -19,7 +19,7 @@ description: Interactive usage-based pricing with a ruler slider, 100-step grid,
 
 <Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
   <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
       <Tab value="npx">
         ```bash
         npx shadcn@latest add @billingsdk/usage-based-pricing
@@ -35,10 +35,15 @@ description: Interactive usage-based pricing with a ruler slider, 100-step grid,
         yarn dlx shadcn@latest add @billingsdk/usage-based-pricing
         ```
       </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/usage-based-pricing
+        ```
+      </Tab>
     </Tabs>
   </Tab>
   <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
       <Tab value="npx">
         ```bash
         npx @billingsdk/cli add usage-based-pricing
@@ -52,6 +57,11 @@ description: Interactive usage-based pricing with a ruler slider, 100-step grid,
       <Tab value="yarn">
         ```bash
         yarn dlx @billingsdk/cli add usage-based-pricing
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add usage-based-pricing
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/payment-card/index.mdx
+++ b/content/docs/components/payment-card/index.mdx
@@ -19,7 +19,7 @@ description: A comprehensive payment interface for processing final transactions
 
 <Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
   <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
       <Tab value="npx">
         ```bash
         npx shadcn@latest add @billingsdk/payment-card
@@ -35,10 +35,15 @@ description: A comprehensive payment interface for processing final transactions
         yarn dlx shadcn@latest add @billingsdk/payment-card
         ```
       </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/payment-card
+        ```
+      </Tab>
     </Tabs>
   </Tab>
   <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
       <Tab value="npx">
         ```bash
         npx @billingsdk/cli add payment-card
@@ -52,6 +57,11 @@ description: A comprehensive payment interface for processing final transactions
       <Tab value="yarn">
         ```bash
         yarn dlx @billingsdk/cli add payment-card
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add payment-card
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/payment-details/index.mdx
+++ b/content/docs/components/payment-details/index.mdx
@@ -21,7 +21,7 @@ Choose your preferred installation method:
 
 <Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
   <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
       <Tab value="npx">
         ```bash
         npx shadcn@latest add @billingsdk/payment-details
@@ -37,10 +37,15 @@ Choose your preferred installation method:
         yarn dlx shadcn@latest add @billingsdk/payment-details
         ```
       </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/payment-details
+        ```
+      </Tab>
     </Tabs>
   </Tab>
   <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
       <Tab value="npx">
         ```bash
         npx @billingsdk/cli add payment-details
@@ -54,6 +59,11 @@ Choose your preferred installation method:
       <Tab value="yarn">
         ```bash
         yarn dlx @billingsdk/cli add payment-details
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add payment-details
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/payment-method-selector/index.mdx
+++ b/content/docs/components/payment-method-selector/index.mdx
@@ -22,7 +22,7 @@ description: Interactive selector for Cards, Digital Wallets, UPI (India), and B
 
 <Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
   <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
       <Tab value="npx">
         ```bash
         npx shadcn@latest add @billingsdk/payment-method-selector
@@ -38,10 +38,15 @@ description: Interactive selector for Cards, Digital Wallets, UPI (India), and B
         yarn dlx shadcn@latest add @billingsdk/payment-method-selector
         ```
       </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/payment-method-selector
+        ```
+      </Tab>
     </Tabs>
   </Tab>
   <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
       <Tab value="npx">
         ```bash
         npx @billingsdk/cli add payment-method-selector
@@ -55,6 +60,11 @@ description: Interactive selector for Cards, Digital Wallets, UPI (India), and B
       <Tab value="yarn">
         ```bash
         yarn dlx @billingsdk/cli add payment-method-selector
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add payment-method-selector
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/payment-success-dialog/index.mdx
+++ b/content/docs/components/payment-success-dialog/index.mdx
@@ -20,7 +20,7 @@ description: A confirmation dialog that celebrates a successful payment with the
 
 <Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
   <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
       <Tab value="npx">
         ```bash
         npx shadcn@latest add @billingsdk/payment-success-dialog
@@ -36,10 +36,15 @@ description: A confirmation dialog that celebrates a successful payment with the
         yarn dlx shadcn@latest add @billingsdk/payment-success-dialog
         ```
       </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/payment-success-dialog
+        ```
+      </Tab>
     </Tabs>
   </Tab>
   <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
       <Tab value="npx">
         ```bash
         npx @billingsdk/cli add payment-success-dialog
@@ -53,6 +58,11 @@ description: A confirmation dialog that celebrates a successful payment with the
       <Tab value="yarn">
         ```bash
         yarn dlx @billingsdk/cli add payment-success-dialog
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add payment-success-dialog
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/pricing-table/pricing-table-eight.mdx
+++ b/content/docs/components/pricing-table/pricing-table-eight.mdx
@@ -17,7 +17,7 @@ description: The Pricing Table Eight component provides a feature-comparison pri
 
 ## Installation
 
-<Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+<Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
   <Tab value="npx">
     ```bash
     npx shadcn@latest add @billingsdk/pricing-table-eight
@@ -31,6 +31,11 @@ description: The Pricing Table Eight component provides a feature-comparison pri
   <Tab value="yarn">
     ```bash
     yarn dlx shadcn@latest add @billingsdk/pricing-table-eight
+    ```
+  </Tab>
+  <Tab value="bun">
+    ```bash
+    bunx shadcn@latest add @billingsdk/pricing-table-eight
     ```
   </Tab>
 </Tabs>

--- a/content/docs/components/pricing-table/pricing-table-four.mdx
+++ b/content/docs/components/pricing-table/pricing-table-four.mdx
@@ -17,7 +17,7 @@ description: The Pricing Table Four component provides a modern gradient design 
 
 ## Installation
 
-<Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+<Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
   <Tab value="npx">
     ```bash
     npx shadcn@latest add @billingsdk/pricing-table-four
@@ -31,6 +31,11 @@ description: The Pricing Table Four component provides a modern gradient design 
   <Tab value="yarn">
     ```bash
     yarn dlx shadcn@latest add @billingsdk/pricing-table-four
+    ```
+  </Tab>
+  <Tab value="bun">
+    ```bash
+    bunx shadcn@latest add @billingsdk/pricing-table-four
     ```
   </Tab>
 </Tabs>

--- a/content/docs/components/pricing-table/pricing-table-seven.mdx
+++ b/content/docs/components/pricing-table/pricing-table-seven.mdx
@@ -17,7 +17,7 @@ description: The Pricing Table Seven component provides a Modern pricing design 
 
 ## Installation
 
-<Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+<Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
   <Tab value="npx">
     ```bash
     npx shadcn@latest add @billingsdk/pricing-table-seven
@@ -31,6 +31,11 @@ description: The Pricing Table Seven component provides a Modern pricing design 
   <Tab value="yarn">
     ```bash
     yarn dlx shadcn@latest add @billingsdk/pricing-table-seven
+    ```
+  </Tab>
+  <Tab value="bun">
+    ```bash
+    bunx shadcn@latest add @billingsdk/pricing-table-seven
     ```
   </Tab>
 </Tabs>

--- a/content/docs/components/pricing-table/pricing-table-six.mdx
+++ b/content/docs/components/pricing-table/pricing-table-six.mdx
@@ -17,7 +17,7 @@ description: The Pricing Table Six component provides a modern gradient design f
 
 ## Installation
 
-<Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+<Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
   <Tab value="npx">
     ```bash
     npx shadcn@latest add @billingsdk/pricing-table-six
@@ -31,6 +31,11 @@ description: The Pricing Table Six component provides a modern gradient design f
   <Tab value="yarn">
     ```bash
     yarn dlx shadcn@latest add @billingsdk/pricing-table-six
+    ```
+  </Tab>
+  <Tab value="bun">
+    ```bash
+    bunx shadcn@latest add @billingsdk/pricing-table-six
     ```
   </Tab>
 </Tabs>

--- a/content/docs/components/pricing-table/pricing-table-three.mdx
+++ b/content/docs/components/pricing-table/pricing-table-three.mdx
@@ -19,7 +19,7 @@ description: The Pricing Table Three component provides a third design option fo
 
 <Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
   <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
       <Tab value="npx">
         ```bash
         npx shadcn@latest add @billingsdk/pricing-table-three
@@ -35,10 +35,15 @@ description: The Pricing Table Three component provides a third design option fo
         yarn dlx shadcn@latest add @billingsdk/pricing-table-three
         ```
       </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/pricing-table-three
+        ```
+      </Tab>
     </Tabs>
   </Tab>
   <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
       <Tab value="npx">
         ```bash
         npx @billingsdk/cli add pricing-table-three
@@ -52,6 +57,11 @@ description: The Pricing Table Three component provides a third design option fo
       <Tab value="yarn">
         ```bash
         yarn dlx @billingsdk/cli add pricing-table-three
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add pricing-table-three
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/pricing-table/pricing-table-two.mdx
+++ b/content/docs/components/pricing-table/pricing-table-two.mdx
@@ -38,7 +38,7 @@ description: The Pricing Table Two component offers an alternative design approa
 
 <Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
   <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
       <Tab value="npx">
         ```bash
         npx shadcn@latest add @billingsdk/pricing-table-two
@@ -54,10 +54,15 @@ description: The Pricing Table Two component offers an alternative design approa
         yarn dlx shadcn@latest add @billingsdk/pricing-table-two
         ```
       </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/pricing-table-two
+        ```
+      </Tab>
     </Tabs>
   </Tab>
   <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
       <Tab value="npx">
         ```bash
         npx @billingsdk/cli add pricing-table-two
@@ -71,6 +76,11 @@ description: The Pricing Table Two component offers an alternative design approa
       <Tab value="yarn">
         ```bash
         yarn dlx @billingsdk/cli add pricing-table-two
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add pricing-table-two
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/upcoming-charges/index.mdx
+++ b/content/docs/components/upcoming-charges/index.mdx
@@ -26,7 +26,7 @@ description: The Upcoming Charges component displays information about upcoming 
 
 <Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
   <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
       <Tab value="npx">
         ```bash
         npx shadcn@latest add @billingsdk/upcoming-charges
@@ -42,10 +42,15 @@ description: The Upcoming Charges component displays information about upcoming 
         yarn dlx shadcn@latest add @billingsdk/upcoming-charges
         ```
       </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/upcoming-charges
+        ```
+      </Tab>
     </Tabs>
   </Tab>
   <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
       <Tab value="npx">
         ```bash
         npx @billingsdk/cli add upcoming-charges
@@ -59,6 +64,11 @@ description: The Upcoming Charges component displays information about upcoming 
       <Tab value="yarn">
         ```bash
         yarn dlx @billingsdk/cli add upcoming-charges
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add upcoming-charges
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/update-plan/update-plan-card.mdx
+++ b/content/docs/components/update-plan/update-plan-card.mdx
@@ -20,7 +20,7 @@ description: The Update Plan Card component provides a compact, card-based inter
 
 <Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
   <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
       <Tab value="npx">
         ```bash
         npx shadcn@latest add @billingsdk/update-plan-card
@@ -36,10 +36,15 @@ description: The Update Plan Card component provides a compact, card-based inter
         yarn dlx shadcn@latest add @billingsdk/update-plan-card
         ```
       </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/update-plan-card
+        ```
+      </Tab>
     </Tabs>
   </Tab>
   <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
       <Tab value="npx">
         ```bash
         npx @billingsdk/cli add update-plan-card
@@ -53,6 +58,11 @@ description: The Update Plan Card component provides a compact, card-based inter
       <Tab value="yarn">
         ```bash
         yarn dlx @billingsdk/cli add update-plan-card
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add update-plan-card
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/update-plan/update-plan-dialog.mdx
+++ b/content/docs/components/update-plan/update-plan-dialog.mdx
@@ -20,7 +20,7 @@ description: The Update Plan Dialog component provides an interactive interface 
 
 <Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
   <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
       <Tab value="npx">
         ```bash
         npx shadcn@latest add @billingsdk/update-plan-dialog
@@ -36,10 +36,15 @@ description: The Update Plan Dialog component provides an interactive interface 
         yarn dlx shadcn@latest add @billingsdk/update-plan-dialog
         ```
       </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/update-plan-dialog
+        ```
+      </Tab>
     </Tabs>
   </Tab>
   <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
       <Tab value="npx">
         ```bash
         npx @billingsdk/cli add update-plan-dialog
@@ -53,6 +58,11 @@ description: The Update Plan Dialog component provides an interactive interface 
       <Tab value="yarn">
         ```bash
         yarn dlx @billingsdk/cli add update-plan-dialog
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add update-plan-dialog
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/usage-meter/usage-meter-linear.mdx
+++ b/content/docs/components/usage-meter/usage-meter-linear.mdx
@@ -23,7 +23,7 @@ You can change the progress color of the usage meter to `default` or `usage`.
 
 <Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
   <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
       <Tab value="npx">
         ```bash
         npx shadcn@latest add @billingsdk/usage-meter-linear
@@ -39,10 +39,15 @@ You can change the progress color of the usage meter to `default` or `usage`.
         yarn dlx shadcn@latest add @billingsdk/usage-meter-linear
         ```
       </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/usage-meter-linear
+        ```
+      </Tab>
     </Tabs>
   </Tab>
   <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
       <Tab value="npx">
         ```bash
         npx @billingsdk/cli add usage-meter-linear
@@ -56,6 +61,11 @@ You can change the progress color of the usage meter to `default` or `usage`.
       <Tab value="yarn">
         ```bash
         yarn dlx @billingsdk/cli add usage-meter-linear
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add usage-meter-linear
         ```
       </Tab>
     </Tabs>

--- a/content/docs/components/usage-table/index.mdx
+++ b/content/docs/components/usage-table/index.mdx
@@ -19,7 +19,7 @@ description: Per-model LLM usage with token counts, cache reads, and API cost.
 
 <Tabs items={['shadcn', 'billingSDK']} defaultValue="shadcn" className="bg-transparent border-none">
   <Tab value="shadcn" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="installation-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="installation-tabs">
       <Tab value="npx">
         ```bash
         npx shadcn@latest add @billingsdk/usage-table
@@ -35,10 +35,15 @@ description: Per-model LLM usage with token counts, cache reads, and API cost.
         yarn dlx shadcn@latest add @billingsdk/usage-table
         ```
       </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx shadcn@latest add @billingsdk/usage-table
+        ```
+      </Tab>
     </Tabs>
   </Tab>
   <Tab value="billingSDK" className="border-none bg-transparent p-0 mt-3">
-    <Tabs items={['npx', 'pnpm', 'yarn']} defaultValue="npx" groupId="billingsdk-cli-tabs">
+    <Tabs items={['npx', 'pnpm', 'yarn', 'bun']} defaultValue="npx" groupId="billingsdk-cli-tabs">
       <Tab value="npx">
         ```bash
         npx @billingsdk/cli add usage-table
@@ -52,6 +57,11 @@ description: Per-model LLM usage with token counts, cache reads, and API cost.
       <Tab value="yarn">
         ```bash
         yarn dlx @billingsdk/cli add usage-table
+        ```
+      </Tab>
+      <Tab value="bun">
+        ```bash
+        bunx @billingsdk/cli add usage-table
         ```
       </Tab>
     </Tabs>


### PR DESCRIPTION
### Summary
Added bun installation support across all component docs for consistency.

### Changes
- Add bun support to 23 component installation tabs
- Ensure consistency across shadcn and billingSDK installation methods
- Add bunx commands following project conventions

### Screenshots/Recordings (if UI)
Before - 
<img width="1361" height="426" alt="old-dodo" src="https://github.com/user-attachments/assets/2b1c8107-cdcb-46d1-b9b5-fbe91a495dbc" />

After - 
<img width="1365" height="472" alt="new-dodo" src="https://github.com/user-attachments/assets/5adfbe61-3f54-45a9-a598-4110fefa51df" />

### How to Test
Steps to validate locally:
1. npm ci
2. npm run typecheck
3. npm run build

### Checklist
- [x] Title is clear and descriptive
- [x] Related issue linked (if any)
- [x] Tests or manual verification steps included
- [ ] CI passes (typecheck & build)
- [x] Docs updated (if needed)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added Bun as an installation option across component docs, alongside npx, pnpm, and yarn.
  - Introduced bunx command examples in shadcn and BillingSDK CLI tabs for each component.
  - Preserved existing defaults (e.g., npx) and existing install flows.
  - Updated yarn instructions to use yarn dlx where applicable (e.g., coupon).
  - No behavioral or API changes; improvements are limited to installation guidance and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->