### PR TITLE
fix: responsive layout of Pricing Table 8

### DIFF
--- a/src/registry/billingsdk/pricing-table-eight.tsx
+++ b/src/registry/billingsdk/pricing-table-eight.tsx
@@ -249,8 +249,7 @@ export function PricingTableEight({
 
         {/* Pricing Cards */}
         <div className="mt-16">
-          <div className="grid grid-cols-1 lg:grid-cols-4 gap-4 mb-8">
-            <div></div>
+          <div className="flex flex-col justify-center lg:flex-row lg:space-x-6 space-y-6 lg:space-y-0 mb-12">
             {plans.map((plan) => (
               <motion.div
                 key={plan.id}


### PR DESCRIPTION
### Summary
Fix responsive layout of Pricing Table 8
closes #252

### Changes
- use flex instead of grid
- remove redundant div

### Screenshots/Recordings (if UI)
<img width="3072" height="1558" alt="image" src="https://github.com/user-attachments/assets/2b9e1bdd-a1ea-4864-af48-9a6a7cd3a0f8" />


### How to Test
Steps to validate locally:
1. npm ci
2. npm run typecheck
3. npm run build

### Checklist
- [x] Title is clear and descriptive
- [x] Related issue linked (if any)
- [x] Tests or manual verification steps included
- [x] CI passes (typecheck & build)
- [x] Docs updated (if needed)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Pricing table now uses a more responsive layout that adapts card arrangement and spacing across screen sizes, improving visual balance on large displays.
  * Removed an unused placeholder element for a cleaner layout and more consistent spacing.
* **Refactor**
  * Simplified pricing table structure by rendering plan cards directly, reducing DOM complexity and improving responsiveness and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->