### PR TITLE
fix:sidebar toggle button hidden on large screens

### DIFF
--- a/src/app/global.css
+++ b/src/app/global.css
@@ -191,3 +191,16 @@ pre[class*="language-"]::-webkit-scrollbar {
 .scroll-smooth {
   scroll-behavior: smooth;
 }
+
+@media (min-width: 1276px) {
+
+  /* Hide collapse button on desktop */
+  button[aria-label="Collapse Sidebar"] {
+    display: none;
+  }
+
+  /* Hide floating search toggle on large screens */
+  [data-search] {
+    display: none;
+  }
+}


### PR DESCRIPTION
### Summary
- This PR fixes the sidebar toggle button, making it hidden on large screens.


### Changes
- Hides the toggle and search buttons on large screens.
- On large screens, collapsing the sidebar doesn't affect the layout, so it's better to just hide the button.

### Screenshots/Recordings (if UI)
- Before ( Using the toggle contribute nothing to our ui on large screens.)

https://github.com/user-attachments/assets/a5b34453-6ba7-4c7f-af73-ff0c93833b7d

- After 

https://github.com/user-attachments/assets/1d549eb9-9c16-4c01-ae6d-10f8013cbf05


### How to Test
Steps to validate locally:
1. npm ci
2. npm run typecheck
3. npm run build

### Checklist
- [X] Title is clear and descriptive
- [X] Related issue linked (if any)
- [X] Tests or manual verification steps included
- [X] CI passes (typecheck & build)
- [X] Docs updated (if needed)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated responsive layout for desktop screens (≥1276px): the “Collapse Sidebar” control and on-page search UI are now hidden to streamline the interface.
  - Mobile and tablet views remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->