### PR TITLE
feat: add Stripe support for Fastify template

### DIFF
--- a/packages/templates/fastify/src/lib/stripe.ts
+++ b/packages/templates/fastify/src/lib/stripe.ts
@@ -1,0 +1,128 @@
+import Stripe from 'stripe';
+
+let _stripe: Stripe | null = null;
+
+export const getStripe = (): Stripe => {
+  const key = process.env.STRIPE_SECRET_KEY;
+  if (!key) {
+    throw new Error(`
+      STRIPE_SECRET_KEY environment variable is missing.
+      
+      Please check:
+      1. Your .env file exists in the project root
+      2. The file contains: STRIPE_SECRET_KEY=<your-secret-key>
+      3. You've restarted your development server
+      4. No extra quotes or spaces in the .env file
+    `);
+  }
+
+  if (!_stripe) {
+    _stripe = new Stripe(key);
+  }
+  return _stripe;
+};
+
+export type Product = Stripe.Product;
+export type Customer = Stripe.Customer;
+export type Subscription = Stripe.Subscription;
+export type PaymentIntent = Stripe.PaymentIntent;
+
+export async function getProducts(): Promise<Product[]> {
+  try {
+    const stripe = getStripe();
+    const { data } = await stripe.products.list({ limit: 100 });
+    return data;
+  } catch (error) {
+    console.error('Error fetching products', error);
+    throw new Error('Failed to fetch products');
+  }
+}
+
+export async function getProduct(product_id: string): Promise<Product> {
+  try {
+    const stripe = getStripe();
+    return await stripe.products.retrieve(product_id);
+  } catch (error) {
+    console.error('Error fetching product', error);
+    throw new Error('Failed to fetch product');
+  }
+}
+
+export async function getCustomer(customer_id: string): Promise<Customer | Stripe.DeletedCustomer> {
+  try {
+    const stripe = getStripe();
+    const customer = await stripe.customers.retrieve(customer_id);
+
+    if ((customer as Stripe.DeletedCustomer).deleted) {
+      return customer as Stripe.DeletedCustomer;
+    }
+    return customer as Customer;
+  } catch (error) {
+    console.error('Error fetching customer', error);
+    throw new Error('Failed to fetch customer');
+  }
+}
+
+export async function createCustomer(params: Stripe.CustomerCreateParams): Promise<Customer> {
+  try {
+    const stripe = getStripe();
+    return await stripe.customers.create(params);
+  } catch (error) {
+    console.error('Error creating customer', error);
+    throw new Error('Failed to create customer');
+  }
+}
+
+export async function updateCustomer(customer_id: string, params: Stripe.CustomerUpdateParams): Promise<Customer> {
+  try {
+    const stripe = getStripe();
+    return await stripe.customers.update(customer_id, params);
+  } catch (error) {
+    console.error('Error updating customer', error);
+    throw new Error('Failed to update customer');
+  }
+}
+
+export async function getCustomerSubscriptions(customer_id: string): Promise<Subscription[]> {
+  try {
+    const stripe = getStripe();
+    const { data } = await stripe.subscriptions.list({ customer: customer_id });
+    return data;
+  } catch (error) {
+    console.error('Error fetching subscriptions', error);
+    throw new Error('Failed to fetch subscriptions');
+  }
+}
+
+export async function getCustomerPayments(customer_id: string): Promise<PaymentIntent[]> {
+  try {
+    const stripe = getStripe();
+    const { data } = await stripe.paymentIntents.list({ customer: customer_id, limit: 100 });
+    return data;
+  } catch (error) {
+    console.error('Error fetching payments', error);
+    throw new Error('Failed to fetch payments');
+  }
+}
+
+export async function checkout(opts: {
+  price_id: string;
+  customer_id?: string;
+  success_url: string;
+  cancel_url: string;
+}): Promise<{ checkout_url: string }> {
+  try {
+    const stripe = getStripe();
+    const session = await stripe.checkout.sessions.create({
+      mode: 'subscription',
+      line_items: [{ price: opts.price_id, quantity: 1 }],
+      customer: opts.customer_id ?? '',
+      success_url: opts.success_url,
+      cancel_url: opts.cancel_url,
+    });
+    return { checkout_url: session.url! };
+  } catch (error) {
+    console.error('Error creating checkout session', error);
+    throw new Error('Failed to create checkout session');
+  }
+}

--- a/packages/templates/fastify/src/routes/route.ts
+++ b/packages/templates/fastify/src/routes/route.ts
@@ -1,3 +1,4 @@
 import dodopaymentsRoutes from './dodopayments/route'
+import stripeRoutes from './stripe/route'
 
-export { dodopaymentsRoutes }
+export { dodopaymentsRoutes, stripeRoutes }

--- a/packages/templates/fastify/src/routes/stripe/checkout.ts
+++ b/packages/templates/fastify/src/routes/stripe/checkout.ts
@@ -1,0 +1,87 @@
+// @ts-nocheck
+import { FastifyInstance } from 'fastify'
+import { z } from 'zod'
+import type Stripe from 'stripe'
+import { getStripe } from '../../lib/stripe'
+
+export default async function checkoutRoutes(fastify: FastifyInstance) {
+  const stripe = getStripe()
+
+  const productCartItemSchema = z.object({
+    price_id: z.string().min(1, 'Price ID is required'),
+    quantity: z.number().int().min(1, 'Quantity must be at least 1'),
+  })
+
+  const attachExistingCustomerSchema = z.object({
+    customer_id: z.string().min(1, 'Customer ID is required'),
+  })
+
+  const newCustomerSchema = z.object({
+    email: z.string().email('Invalid email format'),
+    name: z.string().min(1, 'Name is required'),
+    phone_number: z.string().optional().nullable(),
+    create_new_customer: z.boolean().optional(),
+  })
+
+  const customerSchema = z.union([attachExistingCustomerSchema, newCustomerSchema])
+
+  const checkoutSessionSchema = z.object({
+    productCart: z.array(productCartItemSchema).min(1, 'At least one product is required'),
+    customer: customerSchema.optional(),
+    success_url: z.string().url('Success URL must be a valid URL'),
+    cancel_url: z.string().url('Cancel URL must be a valid URL'),
+    metadata: z.record(z.string(), z.string()).optional(),
+  })
+
+  fastify.post('/', async (request, reply) => {
+    try {
+      const validationResult = checkoutSessionSchema.safeParse(request.body)
+      if (!validationResult.success) {
+        return reply.status(400).send({
+          error: 'Validation failed',
+          details: validationResult.error.issues.map((issue) => ({
+            field: issue.path.join('.'),
+            message: issue.message,
+          })),
+        })
+      }
+
+      const { productCart, customer, success_url, cancel_url, metadata } = validationResult.data
+
+      let customerId: string | undefined
+      if (customer && 'email' in customer) {
+        const stripeCustomer = await stripe.customers.create({
+          email: customer.email ?? '',
+          name: customer.name ?? '',
+          phone: customer.phone_number ?? '',
+        })
+        customerId = stripeCustomer.id
+      } else if (customer && 'customer_id' in customer) {
+        customerId = customer.customer_id
+      }
+
+      const sessionParams: Stripe.Checkout.SessionCreateParams = {
+        payment_method_types: ['card'],
+        line_items: productCart.map((item) => ({
+          price: item.price_id,
+          quantity: item.quantity,
+        })),
+        mode: 'payment',
+        success_url: success_url + '?session_id={CHECKOUT_SESSION_ID}',
+        cancel_url: cancel_url,
+        ...(metadata ? { metadata } : {}),
+      }
+
+      if (customerId) {
+        sessionParams.customer = customerId
+      }
+
+      const session = await stripe.checkout.sessions.create(sessionParams)
+
+      return reply.send({ url: session.url })
+    } catch (error) {
+      request.log.error({ err: error }, 'Error in Stripe checkout POST handler')
+      return reply.status(500).send({ error: 'Internal server error' })
+    }
+  })
+}

--- a/packages/templates/fastify/src/routes/stripe/customer.ts
+++ b/packages/templates/fastify/src/routes/stripe/customer.ts
@@ -1,0 +1,138 @@
+// @ts-nocheck
+import { FastifyInstance } from 'fastify'
+import { z } from 'zod'
+import type Stripe from 'stripe'
+import { getStripe } from '../../lib/stripe'
+
+export default async function customerRoutes(fastify: FastifyInstance) {
+  const stripe = getStripe()
+
+  const customerCreateSchema = z.object({
+    email: z.string().email('Invalid email format'),
+    name: z.string().min(1, 'Name is required'),
+    phone: z.string().optional().nullable(),
+    metadata: z.record(z.string(), z.string()).optional(),
+  })
+
+  const customerUpdateSchema = z.object({
+    email: z.string().email('Invalid email format').optional(),
+    name: z.string().min(1, 'Name is required').optional(),
+    phone: z.string().optional().nullable(),
+    metadata: z.record(z.string(), z.string()).optional(),
+  })
+
+  // Get customer by ID
+  fastify.get('/', async (request, reply) => {
+    try {
+      const { customer_id } = request.query as Record<string, any>
+      if (!customer_id || typeof customer_id !== 'string') {
+        return reply.status(400).send({ error: 'customer_id is required' })
+      }
+      
+      const customer = await stripe.customers.retrieve(customer_id)
+      return reply.send(customer)
+    } catch (error) {
+      request.log.error({ err: error }, 'Error fetching customer')
+      return reply.status(500).send({ error: 'Internal server error' })
+    }
+  })
+
+  // Create customer
+  fastify.post('/', async (request, reply) => {
+    try {
+      const validationResult = customerCreateSchema.safeParse(request.body)
+      if (!validationResult.success) {
+        return reply.status(400).send({
+          error: 'Validation failed',
+          details: validationResult.error.issues.map((issue) => ({
+            field: issue.path.join('.'),
+            message: issue.message,
+          })),
+        })
+      }
+
+      const customer = await stripe.customers.create(validationResult.data)
+      return reply.send(customer)
+    } catch (error) {
+      request.log.error({ err: error }, 'Error creating customer')
+      return reply.status(500).send({ error: 'Internal server error' })
+    }
+  })
+
+  // Update customer
+  fastify.put('/', async (request, reply) => {
+    try {
+      const { customer_id } = request.query as Record<string, any>
+      if (!customer_id || typeof customer_id !== 'string') {
+        return reply.status(400).send({ error: 'customer_id is required' })
+      }
+
+      const validationResult = customerUpdateSchema.safeParse(request.body)
+      if (!validationResult.success) {
+        return reply.status(400).send({
+          error: 'Validation failed',
+          details: validationResult.error.issues.map((issue) => ({
+            field: issue.path.join('.'),
+            message: issue.message,
+          })),
+        })
+      }
+
+      const customer = await stripe.customers.update(customer_id, validationResult.data)
+      return reply.send(customer)
+    } catch (error) {
+      request.log.error({ err: error }, 'Error updating customer')
+      return reply.status(500).send({ error: 'Internal server error' })
+    }
+  })
+
+  // Get customer subscriptions
+  fastify.get('/subscriptions', async (request, reply) => {
+    try {
+      const { customer_id, limit, starting_after } = request.query as Record<string, any>
+      if (!customer_id || typeof customer_id !== 'string') {
+        return reply.status(400).send({ error: 'customer_id is required' })
+      }
+
+      const params: Stripe.SubscriptionListParams = {
+        customer: customer_id,
+        limit: typeof limit === 'string' ? parseInt(limit) : 10,
+      }
+      
+      if (typeof starting_after === 'string') {
+        params.starting_after = starting_after
+      }
+
+      const subscriptions = await stripe.subscriptions.list(params)
+      return reply.send(subscriptions)
+    } catch (error) {
+      request.log.error({ err: error }, 'Error fetching customer subscriptions')
+      return reply.status(500).send({ error: 'Internal server error' })
+    }
+  })
+
+  // Get customer payment intents
+  fastify.get('/payments', async (request, reply) => {
+    try {
+      const { customer_id, limit, starting_after } = request.query as Record<string, any>
+      if (!customer_id || typeof customer_id !== 'string') {
+        return reply.status(400).send({ error: 'customer_id is required' })
+      }
+
+      const params: Stripe.PaymentIntentListParams = {
+        customer: customer_id,
+        limit: typeof limit === 'string' ? parseInt(limit) : 10,
+      }
+      
+      if (typeof starting_after === 'string') {
+        params.starting_after = starting_after
+      }
+
+      const paymentIntents = await stripe.paymentIntents.list(params)
+      return reply.send(paymentIntents)
+    } catch (error) {
+      request.log.error({ err: error }, 'Error fetching customer payments')
+      return reply.status(500).send({ error: 'Internal server error' })
+    }
+  })
+}

--- a/packages/templates/fastify/src/routes/stripe/payments.ts
+++ b/packages/templates/fastify/src/routes/stripe/payments.ts
@@ -1,0 +1,115 @@
+// @ts-nocheck
+import { FastifyInstance } from 'fastify'
+import { z } from 'zod'
+import type Stripe from 'stripe'
+import { getStripe } from '../../lib/stripe'
+
+export default async function paymentsRoutes(fastify: FastifyInstance) {
+  const stripe = getStripe()
+
+  const refundSchema = z.object({
+    amount: z.number().int().min(1).optional(),
+    reason: z.enum(['duplicate', 'fraudulent', 'requested_by_customer']).optional(),
+    metadata: z.record(z.string(), z.string()).optional(),
+  })
+
+  // Get payment intent by ID
+  fastify.get('/', async (request, reply) => {
+    try {
+      const { payment_intent_id } = request.query as Record<string, any>
+      if (!payment_intent_id || typeof payment_intent_id !== 'string') {
+        return reply.status(400).send({ error: 'payment_intent_id is required' })
+      }
+      
+      const paymentIntent = await stripe.paymentIntents.retrieve(payment_intent_id)
+      return reply.send(paymentIntent)
+    } catch (error) {
+      request.log.error({ err: error }, 'Error fetching payment intent')
+      return reply.status(500).send({ error: 'Internal server error' })
+    }
+  })
+
+  // List payment intents
+  fastify.get('/list', async (request, reply) => {
+    try {
+      const { customer_id, limit, starting_after } = request.query as Record<string, any>
+      const params: Stripe.PaymentIntentListParams = {}
+      
+      if (typeof customer_id === 'string') params.customer = customer_id
+      if (typeof limit === 'string') params.limit = parseInt(limit)
+      if (typeof starting_after === 'string') params.starting_after = starting_after
+
+      const paymentIntents = await stripe.paymentIntents.list(params)
+      return reply.send(paymentIntents)
+    } catch (error) {
+      request.log.error({ err: error }, 'Error fetching payment intents list')
+      return reply.status(500).send({ error: 'Internal server error' })
+    }
+  })
+
+  // Create refund for a charge
+  fastify.post('/refund', async (request, reply) => {
+    try {
+      const { charge_id } = request.query as Record<string, any>
+      if (!charge_id || typeof charge_id !== 'string') {
+        return reply.status(400).send({ error: 'charge_id is required' })
+      }
+
+      const validationResult = refundSchema.safeParse(request.body)
+      if (!validationResult.success) {
+        return reply.status(400).send({
+          error: 'Validation failed',
+          details: validationResult.error.issues.map((issue) => ({
+            field: issue.path.join('.'),
+            message: issue.message,
+          })),
+        })
+      }
+
+      const refundParams: Stripe.RefundCreateParams = {
+        charge: charge_id,
+        ...validationResult.data,
+      }
+
+      const refund = await stripe.refunds.create(refundParams)
+      return reply.send(refund)
+    } catch (error) {
+      request.log.error({ err: error }, 'Error creating refund')
+      return reply.status(500).send({ error: 'Internal server error' })
+    }
+  })
+
+  // Get refund by ID
+  fastify.get('/refund', async (request, reply) => {
+    try {
+      const { refund_id } = request.query as Record<string, any>
+      if (!refund_id || typeof refund_id !== 'string') {
+        return reply.status(400).send({ error: 'refund_id is required' })
+      }
+      
+      const refund = await stripe.refunds.retrieve(refund_id)
+      return reply.send(refund)
+    } catch (error) {
+      request.log.error({ err: error }, 'Error fetching refund')
+      return reply.status(500).send({ error: 'Internal server error' })
+    }
+  })
+
+  // List refunds
+  fastify.get('/refunds', async (request, reply) => {
+    try {
+      const { charge_id, limit, starting_after } = request.query as Record<string, any>
+      const params: Stripe.RefundListParams = {}
+      
+      if (typeof charge_id === 'string') params.charge = charge_id
+      if (typeof limit === 'string') params.limit = parseInt(limit)
+      if (typeof starting_after === 'string') params.starting_after = starting_after
+
+      const refunds = await stripe.refunds.list(params)
+      return reply.send(refunds)
+    } catch (error) {
+      request.log.error({ err: error }, 'Error fetching refunds list')
+      return reply.status(500).send({ error: 'Internal server error' })
+    }
+  })
+}

--- a/packages/templates/fastify/src/routes/stripe/products.ts
+++ b/packages/templates/fastify/src/routes/stripe/products.ts
@@ -1,0 +1,82 @@
+// @ts-nocheck
+import { FastifyInstance } from 'fastify'
+import type Stripe from 'stripe'
+import { getStripe } from '../../lib/stripe'
+
+export default async function productsRoutes(fastify: FastifyInstance) {
+  const stripe = getStripe()
+
+  // List products
+  fastify.get('/', async (request, reply) => {
+    try {
+      const { limit, starting_after, active } = request.query as Record<string, any>
+      const params: Stripe.ProductListParams = {}
+      
+      if (typeof limit === 'string') params.limit = parseInt(limit)
+      if (typeof starting_after === 'string') params.starting_after = starting_after
+      if (typeof active === 'string') params.active = active === 'true'
+
+      const products = await stripe.products.list(params)
+      return reply.send(products)
+    } catch (error) {
+      request.log.error({ err: error }, 'Error fetching products')
+      return reply.status(500).send({ error: 'Internal server error' })
+    }
+  })
+
+  // Get product by ID
+  fastify.get('/product', async (request, reply) => {
+    try {
+      const { product_id } = request.query as Record<string, any>
+      if (!product_id || typeof product_id !== 'string') {
+        return reply.status(400).send({ error: 'product_id is required' })
+      }
+
+      const product = await stripe.products.retrieve(product_id)
+      return reply.send(product)
+    } catch (error) {
+      request.log.error({ err: error }, 'Error fetching product')
+      return reply.status(500).send({ error: 'Internal server error' })
+    }
+  })
+
+  // List prices for a product
+  fastify.get('/prices', async (request, reply) => {
+    try {
+      const { product_id, limit, starting_after, active } = request.query as Record<string, any>
+      if (!product_id || typeof product_id !== 'string') {
+        return reply.status(400).send({ error: 'product_id is required' })
+      }
+
+      const params: Stripe.PriceListParams = {
+        product: product_id,
+      }
+      
+      if (typeof limit === 'string') params.limit = parseInt(limit)
+      if (typeof starting_after === 'string') params.starting_after = starting_after
+      if (typeof active === 'string') params.active = active === 'true'
+
+      const prices = await stripe.prices.list(params)
+      return reply.send(prices)
+    } catch (error) {
+      request.log.error({ err: error }, 'Error fetching prices')
+      return reply.status(500).send({ error: 'Internal server error' })
+    }
+  })
+
+  // Get price by ID
+  fastify.get('/price', async (request, reply) => {
+    try {
+      const { price_id } = request.query as Record<string, any>
+      if (!price_id || typeof price_id !== 'string') {
+        return reply.status(400).send({ error: 'price_id is required' })
+      }
+
+      const price = await stripe.prices.retrieve(price_id)
+      return reply.send(price)
+    } catch (error) {
+      request.log.error({ err: error }, 'Error fetching price')
+      return reply.status(500).send({ error: 'Internal server error' })
+    }
+  })
+}

--- a/packages/templates/fastify/src/routes/stripe/route.ts
+++ b/packages/templates/fastify/src/routes/stripe/route.ts
@@ -1,0 +1,17 @@
+// @ts-nocheck
+import { FastifyInstance } from 'fastify'
+import checkoutRoutes from './checkout'
+import customerRoutes from './customer'
+import paymentsRoutes from './payments'
+import productsRoutes from './products'
+import subscriptionsRoutes from './subscriptions'
+import webhookRoutes from './webhook'
+
+export default async function stripeRoutes(fastify: FastifyInstance) {
+  await fastify.register(checkoutRoutes, { prefix: '/checkout' })
+  await fastify.register(customerRoutes, { prefix: '/customer' })
+  await fastify.register(paymentsRoutes, { prefix: '/payments' })
+  await fastify.register(productsRoutes, { prefix: '/products' })
+  await fastify.register(subscriptionsRoutes, { prefix: '/subscriptions' })
+  await fastify.register(webhookRoutes, { prefix: '/webhook' })
+}

--- a/packages/templates/fastify/src/routes/stripe/subscriptions.ts
+++ b/packages/templates/fastify/src/routes/stripe/subscriptions.ts
@@ -1,0 +1,130 @@
+// @ts-nocheck
+import { FastifyInstance } from 'fastify'
+import { z } from 'zod'
+import type Stripe from 'stripe'
+import { getStripe } from '../../lib/stripe'
+
+export default async function subscriptionsRoutes(fastify: FastifyInstance) {
+  const stripe = getStripe()
+
+  const subscriptionUpdateSchema = z.object({
+    cancel_at_period_end: z.boolean().optional(),
+    proration_behavior: z.enum(['create_prorations', 'none', 'always_invoice']).optional(),
+    metadata: z.record(z.string(), z.string()).optional(),
+  })
+
+  const subscriptionCancelSchema = z.object({
+    cancel_at_period_end: z.boolean().optional(),
+    cancellation_details: z.object({
+      comment: z.string().optional(),
+      feedback: z.enum(['too_expensive', 'missing_features', 'switched_service', 'unused', 'other']).optional(),
+    }).optional(),
+  })
+
+  // Get subscription by ID
+  fastify.get('/', async (request, reply) => {
+    try {
+      const { subscription_id } = request.query as Record<string, any>
+      if (!subscription_id || typeof subscription_id !== 'string') {
+        return reply.status(400).send({ error: 'subscription_id is required' })
+      }
+      
+      const subscription = await stripe.subscriptions.retrieve(subscription_id)
+      return reply.send(subscription)
+    } catch (error) {
+      request.log.error({ err: error }, 'Error fetching subscription')
+      return reply.status(500).send({ error: 'Internal server error' })
+    }
+  })
+
+  // List subscriptions
+  fastify.get('/list', async (request, reply) => {
+    try {
+      const { customer_id, limit, starting_after, status } = request.query as Record<string, any>
+      const params: Stripe.SubscriptionListParams = {}
+      
+      if (typeof customer_id === 'string') params.customer = customer_id
+      if (typeof limit === 'string') params.limit = parseInt(limit)
+      if (typeof starting_after === 'string') params.starting_after = starting_after
+      if (typeof status === 'string') params.status = status as Stripe.Subscription.Status
+
+      const subscriptions = await stripe.subscriptions.list(params)
+      return reply.send(subscriptions)
+    } catch (error) {
+      request.log.error({ err: error }, 'Error fetching subscriptions list')
+      return reply.status(500).send({ error: 'Internal server error' })
+    }
+  })
+
+  // Update subscription
+  fastify.put('/', async (request, reply) => {
+    try {
+      const { subscription_id } = request.query as Record<string, any>
+      if (!subscription_id || typeof subscription_id !== 'string') {
+        return reply.status(400).send({ error: 'subscription_id is required' })
+      }
+
+      const validationResult = subscriptionUpdateSchema.safeParse(request.body)
+      if (!validationResult.success) {
+        return reply.status(400).send({
+          error: 'Validation failed',
+          details: validationResult.error.issues.map((issue) => ({
+            field: issue.path.join('.'),
+            message: issue.message,
+          })),
+        })
+      }
+
+      const subscription = await stripe.subscriptions.update(subscription_id, validationResult.data)
+      return reply.send(subscription)
+    } catch (error) {
+      request.log.error({ err: error }, 'Error updating subscription')
+      return reply.status(500).send({ error: 'Internal server error' })
+    }
+  })
+
+  // Cancel subscription
+  fastify.delete('/', async (request, reply) => {
+    try {
+      const { subscription_id } = request.query as Record<string, any>
+      if (!subscription_id || typeof subscription_id !== 'string') {
+        return reply.status(400).send({ error: 'subscription_id is required' })
+      }
+
+      const validationResult = subscriptionCancelSchema.safeParse(request.body)
+      if (!validationResult.success) {
+        return reply.status(400).send({
+          error: 'Validation failed',
+          details: validationResult.error.issues.map((issue) => ({
+            field: issue.path.join('.'),
+            message: issue.message,
+          })),
+        })
+      }
+
+      const subscription = await stripe.subscriptions.cancel(subscription_id, validationResult.data)
+      return reply.send(subscription)
+    } catch (error) {
+      request.log.error({ err: error }, 'Error canceling subscription')
+      return reply.status(500).send({ error: 'Internal server error' })
+    }
+  })
+
+  // Resume subscription (if paused)
+  fastify.post('/resume', async (request, reply) => {
+    try {
+      const { subscription_id } = request.query as Record<string, any>
+      if (!subscription_id || typeof subscription_id !== 'string') {
+        return reply.status(400).send({ error: 'subscription_id is required' })
+      }
+
+      const subscription = await stripe.subscriptions.update(subscription_id, {
+        pause_collection: null,
+      })
+      return reply.send(subscription)
+    } catch (error) {
+      request.log.error({ err: error }, 'Error resuming subscription')
+      return reply.status(500).send({ error: 'Internal server error' })
+    }
+  })
+}

--- a/packages/templates/fastify/src/routes/stripe/webhook.ts
+++ b/packages/templates/fastify/src/routes/stripe/webhook.ts
@@ -1,0 +1,127 @@
+// @ts-nocheck
+import { FastifyInstance } from 'fastify'
+import Stripe from 'stripe'
+import { getStripe } from '../../lib/stripe'
+
+export default async function webhookRoutes(fastify: FastifyInstance) {
+  const stripe = getStripe()
+
+  fastify.post('/', {
+    // Note: To get the raw body reliably, register `fastify-raw-body` in your Fastify app:
+    // await fastify.register(import('fastify-raw-body'), { field: 'rawBody', global: false, encoding: 'utf8', runFirst: true })
+    // and enable it for this route via `config: { rawBody: true }`.
+    config: { rawBody: true }
+  }, async (request, reply) => {
+    try {
+      // Validate webhook secret environment variable
+      const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET
+      if (!webhookSecret) {
+        request.log.error('STRIPE_WEBHOOK_SECRET environment variable is missing')
+        return reply.status(500).send({ error: 'Webhook secret not configured' })
+      }
+
+      // Get raw body and signature from headers
+      const rawBody: any = (request as any).rawBody ?? JSON.stringify(request.body ?? {})
+      const sig = request.headers['stripe-signature'] as string
+
+      if (!sig) {
+        request.log.error('Missing Stripe signature header')
+        return reply.status(400).send({ error: 'Missing Stripe signature' })
+      }
+
+      let event: Stripe.Event
+
+      try {
+        event = stripe.webhooks.constructEvent(rawBody, sig, webhookSecret)
+      } catch (err) {
+        request.log.error({ err }, 'Webhook signature verification failed')
+        return reply.status(400).send({ error: 'Webhook verification failed' })
+      }
+
+      // Handle the event
+      try {
+        switch (event.type) {
+          case 'customer.subscription.created':
+          case 'customer.subscription.updated':
+          case 'customer.subscription.deleted': {
+            const subscription = event.data.object as Stripe.Subscription
+            request.log.info(
+              { eventType: event.type, subscriptionId: subscription.id },
+              'Subscription event received'
+            )
+            break
+          }
+
+          case 'payment_intent.succeeded': {
+            const paymentIntent = event.data.object as Stripe.PaymentIntent
+            request.log.info(
+              { paymentIntentId: paymentIntent.id, amount: paymentIntent.amount },
+              'Payment succeeded'
+            )
+            break
+          }
+
+          case 'payment_intent.payment_failed': {
+            const paymentIntent = event.data.object as Stripe.PaymentIntent
+            request.log.error(
+              { 
+                paymentIntentId: paymentIntent.id, 
+                error: paymentIntent.last_payment_error 
+              },
+              'Payment failed'
+            )
+            break
+          }
+
+          case 'charge.refunded': {
+            const charge = event.data.object as Stripe.Charge
+            request.log.info(
+              { chargeId: charge.id, amountRefunded: charge.amount_refunded },
+              'Charge refunded'
+            )
+            break
+          }
+
+          case 'checkout.session.completed': {
+            const session = event.data.object as Stripe.Checkout.Session
+            request.log.info(
+              { sessionId: session.id, customerId: session.customer },
+              'Checkout session completed'
+            )
+            break
+          }
+
+          case 'invoice.payment_succeeded': {
+            const invoice = event.data.object as Stripe.Invoice
+            request.log.info(
+              { invoiceId: invoice.id, customerId: invoice.customer },
+              'Invoice payment succeeded'
+            )
+            break
+          }
+
+          case 'invoice.payment_failed': {
+            const invoice = event.data.object as Stripe.Invoice
+            request.log.error(
+              { invoiceId: invoice.id, customerId: invoice.customer },
+              'Invoice payment failed'
+            )
+            break
+          }
+
+          default:
+            request.log.info({ eventType: event.type }, 'Unhandled event type received')
+            break
+        }
+
+        return reply.status(200).send({ message: 'Webhook processed successfully' })
+      } catch (err) {
+        request.log.error({ err, eventType: event.type }, 'Error handling webhook event')
+        return reply.status(500).send({ error: 'Internal server error' })
+      }
+    } catch (error) {
+      request.log.error({ err: error }, 'Webhook processing failed')
+      return reply.status(500).send({ error: 'Internal server error' })
+    }
+  })
+}

--- a/packages/templates/registry.json
+++ b/packages/templates/registry.json
@@ -316,6 +316,73 @@
       ]
     },
     {
+      "name": "fastify-stripe",
+      "description": "Stripe template for Fastify",
+      "framework": "fastify",
+      "files": [
+        {
+          "path": "packages/templates/fastify/src/lib/stripe.ts",
+          "content": "Stripe library for Fastify",
+          "type": "template",
+          "target": "lib/stripe.ts"
+        },
+        {
+          "path": "packages/templates/fastify/src/routes/stripe/route.ts",
+          "content": "Main Stripe routes for Fastify",
+          "type": "template",
+          "target": "routes/stripe/route.ts"
+        },
+        {
+          "path": "packages/templates/fastify/src/routes/stripe/checkout.ts",
+          "content": "Checkout routes for Fastify",
+          "type": "template",
+          "target": "routes/stripe/checkout.ts"
+        },
+        {
+          "path": "packages/templates/fastify/src/routes/stripe/customer.ts",
+          "content": "Customer management routes for Fastify",
+          "type": "template",
+          "target": "routes/stripe/customer.ts"
+        },
+        {
+          "path": "packages/templates/fastify/src/routes/stripe/payments.ts",
+          "content": "Payment routes for Fastify",
+          "type": "template",
+          "target": "routes/stripe/payments.ts"
+        },
+        {
+          "path": "packages/templates/fastify/src/routes/stripe/products.ts",
+          "content": "Product management routes for Fastify",
+          "type": "template",
+          "target": "routes/stripe/products.ts"
+        },
+        {
+          "path": "packages/templates/fastify/src/routes/stripe/subscriptions.ts",
+          "content": "Subscription management routes for Fastify",
+          "type": "template",
+          "target": "routes/stripe/subscriptions.ts"
+        },
+        {
+          "path": "packages/templates/fastify/src/routes/stripe/webhook.ts",
+          "content": "Webhook handling routes for Fastify",
+          "type": "template",
+          "target": "routes/stripe/webhook.ts"
+        },
+        {
+          "path": "packages/templates/fastify/src/routes/route.ts",
+          "content": "Updated route exports for Fastify",
+          "type": "template",
+          "target": "routes/route.ts"
+        }
+      ],
+      "dependencies": [
+        "stripe",
+        "zod",
+        "fastify",
+        "fastify-raw-body"
+      ]
+    },
+    {
       "name": "hono-dodopayments",
       "description": "DodoPayments template for Hono",
       "framework": "hono",


### PR DESCRIPTION
### Summary
Adds Stripe support for the Fastify template, enabling users to choose between DodoPayments and Stripe providers when using the Fastify framework. This implementation follows the exact patterns established by existing Hono and Express templates.

### Changes
- Added complete Stripe integration for Fastify template
- Created Stripe client library with environment validation (`src/lib/stripe.ts`)
- Implemented all Stripe routes: checkout, customer, payments, products, subscriptions, webhook
- Added secure webhook signature verification using Stripe's verification
- Updated main route exports to include both DodoPayments and Stripe routes
- Added `fastify-stripe` template to registry.json with proper dependencies
- Follows exact Hono/Express implementation patterns for consistency

### Screenshots/Recordings (if UI)
N/A - Backend template implementation only

### How to Test
Steps to validate locally:
1. npm ci
2. npm run typecheck
3. npm run build
4. Test CLI template generation:
   ```bash
   BILLINGSDK_REGISTRY_BASE=http://localhost:3000/tr \
   node packages/cli/dist/index.js init --framework fastify --provider stripe --yes --cwd /tmp/test-stripe
   ```
5. Verify Stripe routes are generated and functional

### Checklist
- [x] Title is clear and descriptive
- [x] Related issue linked (if any) - closes #209
- [x] Tests or manual verification steps included
- [x] CI passes (typecheck & build)
- [x] Docs updated (if needed) - N/A, follows project standards (no template docs)

**closes #209**