### PR TITLE
fix: added support for 180+ currencies in billingsettings2 component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "country-state-city": "^3.2.1",
+        "currency-codes": "^2.2.0",
         "dodopayments": "^1.51.2",
         "framer-motion": "^12.23.22",
         "fumadocs-core": "15.6.10",
@@ -4247,6 +4248,16 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/currency-codes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/currency-codes/-/currency-codes-2.2.0.tgz",
+      "integrity": "sha512-vpbQc5sEYHGdTVAYUhHnKv0DWiYLRvzl/KKyqeHzBh7HD/j3UlWoScpZ9tN/jG6w2feddWoObsBbaNVu5yDapg==",
+      "license": "MIT",
+      "dependencies": {
+        "first-match": "~0.0.1",
+        "nub": "~0.0.0"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "dev": true,
@@ -5434,6 +5445,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/first-match": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/first-match/-/first-match-0.0.1.tgz",
+      "integrity": "sha512-VvKbnaxrC0polTFDC+teKPTdl2mn6B/KUW+WB3C9RzKDeNwbzfLdnUz3FxC+tnjvus6bI0jWrWicQyVIPdS37A==",
+      "license": "MIT"
     },
     "node_modules/flat-cache": {
       "version": "4.0.1",
@@ -8262,6 +8279,15 @@
       },
       "funding": {
         "url": "https://github.com/nebrelbug/npm-to-yarn?sponsor=1"
+      }
+    },
+    "node_modules/nub": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/nub/-/nub-0.0.0.tgz",
+      "integrity": "sha512-dK0Ss9C34R/vV0FfYJXuqDAqHlaW9fvWVufq9MmGF2umCuDbd5GRfRD9fpi/LiM0l4ZXf8IBB+RYmZExqCrf0w==",
+      "license": "MIT/X11",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/object-assign": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "country-state-city": "^3.2.1",
+    "currency-codes": "^2.2.0",
     "dodopayments": "^1.51.2",
     "framer-motion": "^12.23.22",
     "fumadocs-core": "15.6.10",

--- a/src/components/billing-settings-2-demo.tsx
+++ b/src/components/billing-settings-2-demo.tsx
@@ -126,11 +126,6 @@ export function BillingSettings2Demo() {
 						onToggle: (enabled) => handleFeatureToggle('promotionalEmails', enabled),
 					},
 				]}
-				currencyOptions={[
-					{ value: "usd", label: "USD - US Dollar" },
-					{ value: "eur", label: "EUR - Euro" },
-					{ value: "gbp", label: "GBP - British Pound" },
-				]}
 				defaultCurrency={selectedCurrency}
 				onCurrencyChange={createCurrencyChangeHandler(setSelectedCurrency)}
 				onSave={handleSave}

--- a/src/registry/billingsdk/billing-settings-2.tsx
+++ b/src/registry/billingsdk/billing-settings-2.tsx
@@ -190,11 +190,29 @@ export function BillingSettings2({
 		// Get all currency data from the library
 		const currencies = cc.data;
 		return currencies
-			.filter(currency => currency.code) // Filter out any invalid entries
-			.map(currency => ({
-				value: currency.code.toLowerCase(),
-				label: currency.code
-			}))
+			.filter(currency => {
+				// Filter out invalid entries
+				if (!currency.code) return false;
+				
+				// Filter out special currency codes that are not typically used for billing:
+				// - Precious metals (XAU, XAG, XPT, XPD)
+				// - Bond market units (XBA, XBB, XBC, XBD)
+				// - Special drawing rights and test codes (XDR, XTS, XSU, XUA)
+				// - No currency codes (XXX)
+				const specialCodes = ['XAU', 'XAG', 'XPT', 'XPD', 'XBA', 'XBB', 'XBC', 'XBD', 'XDR', 'XTS', 'XSU', 'XUA', 'XXX', 'CLF', 'COU', 'MXV', 'USN', 'UYI', 'UYW', 'CHE', 'CHW'];
+				return !specialCodes.includes(currency.code);
+			})
+			.map(currency => {
+				// Truncate long currency names for better display
+				const currencyName = currency.currency.length > 50 
+					? currency.currency.substring(0, 50) + '...' 
+					: currency.currency;
+				
+				return {
+					value: currency.code.toLowerCase(),
+					label: `${currency.code} - ${currencyName}`
+				};
+			})
 			.sort((a, b) => a.label.localeCompare(b.label)); // Sort alphabetically
 	}, [currencyOptions]);
 	const [validationErrors, setValidationErrors] = useState<ValidationError[]>([]);

--- a/src/registry/billingsdk/billing-settings-2.tsx
+++ b/src/registry/billingsdk/billing-settings-2.tsx
@@ -13,7 +13,8 @@ import {
 } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import { cn } from '@/lib/utils';
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
+import cc from 'currency-codes';
 
 // Define types for our props
 export interface FeatureToggle {
@@ -174,25 +175,28 @@ export function BillingSettings2({
 	onCancel = () => {},
 	saveButtonText = "Save Changes",
 	cancelButtonText = "Cancel",
-	currencyOptions = [
-		{ value: "usd", label: "USD - US Dollar" },
-		{ value: "inr", label: "INR - Indian Rupees" },
-		{ value: "eur", label: "EUR - Euro" },
-		{ value: "gbp", label: "GBP - British Pound" },
-		{ value: "jpy", label: "JPY - Japanese Yen" },
-		{ value: "aud", label: "AUD - Australian Dollar" },
-		{ value: "cad", label: "CAD - Canadian Dollar" },
-		{ value: "cny", label: "CNY - Chinese Yuan" },
-		{ value: "sgd", label: "SGD - Singapore Dollar" },
-		{ value: "chf", label: "CHF - Swiss Franc" },
-		{ value: "zar", label: "ZAR - South African Rand" },
-		{ value: "aed", label: "AED - UAE Dirham" },
-	],
+	currencyOptions,
 	defaultCurrency = "usd",
 	onCurrencyChange = () => {},
 	enableValidation = true,
 	currencyRequired = true,
 }: BillingSettings2Props) {
+	// Generate comprehensive currency options from the currency-codes library
+	const allCurrencyOptions = useMemo(() => {
+		if (currencyOptions) {
+			return currencyOptions;
+		}
+		
+		// Get all currency data from the library
+		const currencies = cc.data;
+		return currencies
+			.filter(currency => currency.code) // Filter out any invalid entries
+			.map(currency => ({
+				value: currency.code.toLowerCase(),
+				label: currency.code
+			}))
+			.sort((a, b) => a.label.localeCompare(b.label)); // Sort alphabetically
+	}, [currencyOptions]);
 	const [validationErrors, setValidationErrors] = useState<ValidationError[]>([]);
 	const [currencyError, setCurrencyError] = useState<string | null>(null);
 
@@ -318,7 +322,7 @@ export function BillingSettings2({
 								<SelectValue placeholder="Select currency" />
 							</SelectTrigger>
 							<SelectContent>
-								{currencyOptions.map((option) => (
+								{allCurrencyOptions.map((option) => (
 									<SelectItem key={option.value} value={option.value}>
 										{option.label}
 									</SelectItem>


### PR DESCRIPTION
### Summary
the current Billing Settings 2 - currency dropdown as only 3 to 4 currency available but the component should have all possible country currency
So according to the issue #265 , I have added all currencies in the list by using a library `currency-codes` 


### Changes
- Key changes in this PR- Install currency-codes package for ISO 4217 currency data
- Update BillingSettings2 to automatically generate 180+ currencies
- Simplify currency labels to show only currency codes (e.g., USD, EUR)
- Maintain backward compatibility with custom currencyOptions prop
- Implement additional filtering to exclude special currency codes not used for billing


### Screenshots/Recordings (if UI)
<img width="1416" height="968" alt="image" src="https://github.com/user-attachments/assets/9ff175c8-cf85-4cb3-a84f-c58e4cba9d25" />


### How to Test
Steps to validate locally:
1. npm ci
2. npm run typecheck
3. npm run build

### Checklist
- [x] Title is clear and descriptive
- [x] Related issue linked (if any)
- [x] Tests or manual verification steps included
- [x] CI passes (typecheck & build)
- [ ] Docs updated (if needed)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Billing Settings: dynamic, auto-generated currency list with clearer "CODE - NAME" labels, alphabetical sorting, and exclusion of unsupported/special currencies.

* **Chores**
  * Added a currency data library to support the dynamic currency options.
  * Updated demo to use the new currency handling (removed reliance on a fixed currencyOptions prop).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->