### PR TITLE
GitHub live star bug fix and Enhancement of adding Open PRs

### DIFF
--- a/src/app/api/github-stars/route.ts
+++ b/src/app/api/github-stars/route.ts
@@ -44,24 +44,13 @@ export async function GET() {
   try {
     // Fetch stars from Shields.io badge
     const starsUrl = `https://img.shields.io/github/stars/${repo}.json`;
-    const starsResponse = await fetch(starsUrl, { 
-      next: { revalidate: 300 }, // Revalidate every 5 minutes
-      signal: controller.signal
-    });
-    
-    // Fetch forks from Shields.io badge
     const forksUrl = `https://img.shields.io/github/forks/${repo}.json`;
-    const forksResponse = await fetch(forksUrl, { 
-      next: { revalidate: 300 }, // Revalidate every 5 minutes
-      signal: controller.signal
-    });
-    
-    // Fetch pull requests from Shields.io badge
-    const prUrl = `https://img.shields.io/github/issues-pr/${repo}.json`;
-    const prResponse = await fetch(prUrl, { 
-      next: { revalidate: 300 }, // Revalidate every 5 minutes
-      signal: controller.signal
-    });
+    const prUrl    = `https://img.shields.io/github/issues-pr/${repo}.json`;
+    const [starsResponse, forksResponse, prResponse] = await Promise.all([
+      fetch(starsUrl, { next: { revalidate: 300 }, signal: controller.signal }),
+      fetch(forksUrl, { next: { revalidate: 300 }, signal: controller.signal }),
+      fetch(prUrl,    { next: { revalidate: 300 }, signal: controller.signal }),
+    ]);
     
     // Clear timeout since fetch completed
     clearTimeout(timeoutId);

--- a/src/app/api/github-stars/route.ts
+++ b/src/app/api/github-stars/route.ts
@@ -56,10 +56,9 @@ export async function GET() {
       signal: controller.signal
     });
     
-    // Fetch closed pull requests from GitHub API through Shields.io
-    // Using a custom query to filter for closed PRs specifically
-    const closedPrsUrl = `https://img.shields.io/github/issues-pr-closed/${repo}.json`;
-    const closedPrsResponse = await fetch(closedPrsUrl, { 
+    // Fetch pull requests from Shields.io badge
+    const prUrl = `https://img.shields.io/github/issues-pr/${repo}.json`;
+    const prResponse = await fetch(prUrl, { 
       next: { revalidate: 300 }, // Revalidate every 5 minutes
       signal: controller.signal
     });
@@ -67,8 +66,8 @@ export async function GET() {
     // Clear timeout since fetch completed
     clearTimeout(timeoutId);
     
-    if (!starsResponse.ok || !forksResponse.ok || !closedPrsResponse.ok) {
-      const fallback = { stars: null, pretty: null, forks: null, forksPretty: null, closedPrs: null, closedPrsPretty: null };
+    if (!starsResponse.ok || !forksResponse.ok || !prResponse.ok) {
+      const fallback = { stars: null, pretty: null, forks: null, forksPretty: null, prs: null, prsPretty: null };
       return new Response(JSON.stringify(fallback), {
         status: 200,
         headers: {
@@ -80,20 +79,20 @@ export async function GET() {
     
     const starsData = await starsResponse.json();
     const forksData = await forksResponse.json();
-    const closedPrsData = await closedPrsResponse.json();
+    const prData = await prResponse.json();
     
     // Extract numbers from Shields.io badge data
     const stars = parseShieldsValue(starsData?.message || '0');
     const forks = parseShieldsValue(forksData?.message || '0');
-    const closedPrs = parseShieldsValue(closedPrsData?.message || '0');
+    const prs = parseShieldsValue(prData?.message || '0');
     
     const body = { 
       stars, 
       pretty: formatStars(stars), 
       forks, 
       forksPretty: formatStars(forks),
-      closedPrs,
-      closedPrsPretty: formatStars(closedPrs)
+      prs,
+      prsPretty: formatStars(prs)
     };
     return new Response(JSON.stringify(body), {
       status: 200,
@@ -113,8 +112,8 @@ export async function GET() {
         pretty: null, 
         forks: null, 
         forksPretty: null,
-        closedPrs: null,
-        closedPrsPretty: null,
+        prs: null,
+        prsPretty: null,
         error: 'Request timeout'
       }), {
         status: 408,
@@ -125,7 +124,7 @@ export async function GET() {
       });
     }
     
-    const fallback = { stars: null, pretty: null, forks: null, forksPretty: null, closedPrs: null, closedPrsPretty: null };
+    const fallback = { stars: null, pretty: null, forks: null, forksPretty: null, prs: null, prsPretty: null };
     return new Response(JSON.stringify(fallback), {
       status: 200,
       headers: {

--- a/src/components/landing/GitHubStarBadge.tsx
+++ b/src/components/landing/GitHubStarBadge.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { FaGithub } from "react-icons/fa";
 import { FiStar } from "react-icons/fi";
 import { GoRepoForked } from "react-icons/go";
+import { FaCodePullRequest } from "react-icons/fa6";
 import { motion, AnimatePresence } from "motion/react";
 
 type StarResponse = {
@@ -12,11 +13,13 @@ type StarResponse = {
   pretty: string | null;
   forks: number | null;
   forksPretty: string | null;
+  closedPrs: number | null;
+  closedPrsPretty: string | null;
 };
 
 export default function GitHubStarBadge() {
   const [display, setDisplay] = useState<{
-    kind: "stars" | "forks";
+    kind: "stars" | "forks" | "closedPrs";
     text: string;
   } | null>(null);
   const [metrics, setMetrics] = useState<StarResponse | null>(null);
@@ -92,6 +95,9 @@ export default function GitHubStarBadge() {
         if (prev.kind === "stars") {
           const text = formatApprox(metrics.forks);
           return { kind: "forks", text };
+        } else if (prev.kind === "forks") {
+          const text = formatApprox(metrics.closedPrs);
+          return { kind: "closedPrs", text };
         } else {
           const text = formatApprox(metrics.stars);
           return { kind: "stars", text };
@@ -153,8 +159,10 @@ export default function GitHubStarBadge() {
             >
               {display.kind === "stars" ? (
                 <FiStar className="h-3.5 w-3.5" />
-              ) : (
+              ) : display.kind === "forks" ? (
                 <GoRepoForked className="h-3.5 w-3.5" />
+              ) : (
+                <FaCodePullRequest className="h-3.5 w-3.5" />
               )}
             </motion.span>
           )}

--- a/src/components/landing/GitHubStarBadge.tsx
+++ b/src/components/landing/GitHubStarBadge.tsx
@@ -13,13 +13,13 @@ type StarResponse = {
   pretty: string | null;
   forks: number | null;
   forksPretty: string | null;
-  closedPrs: number | null;
-  closedPrsPretty: string | null;
+  prs: number | null;
+  prsPretty: string | null;
 };
 
 export default function GitHubStarBadge() {
   const [display, setDisplay] = useState<{
-    kind: "stars" | "forks" | "closedPrs";
+    kind: "stars" | "forks" | "prs";
     text: string;
   } | null>(null);
   const [metrics, setMetrics] = useState<StarResponse | null>(null);
@@ -96,8 +96,8 @@ export default function GitHubStarBadge() {
           const text = formatApprox(metrics.forks);
           return { kind: "forks", text };
         } else if (prev.kind === "forks") {
-          const text = formatApprox(metrics.closedPrs);
-          return { kind: "closedPrs", text };
+          const text = formatApprox(metrics.prs);
+          return { kind: "prs", text };
         } else {
           const text = formatApprox(metrics.stars);
           return { kind: "stars", text };


### PR DESCRIPTION
### Summary
#286 Fixed the bug of not fetching and displaying current values, also added open PRs icon and live count as well.

### Changes
- Added fix of fetching and displaying live count of stars, forks.
- Added enhancement for displaying Open PRs.

### Screenshots/Recordings (if UI)
before: 
<img width="209" height="80" alt="image" src="https://github.com/user-attachments/assets/16a53ec0-41b0-412f-b7e6-ef67ba0379c0" />

after:
<img width="209" height="64" alt="image" src="https://github.com/user-attachments/assets/25bd29e6-ed8a-49d4-8813-aa9bbd5782ea" />

Enhancement:
<img width="221" height="59" alt="image" src="https://github.com/user-attachments/assets/187eb108-101f-4eb4-8530-a5adebc3927c" />


### How to Test
Steps to validate locally:
1. npm npm dev

### Checklist
- [x] Title is clear and descriptive
- [x] Related issue linked (if any)
- [x] Tests or manual verification steps included
- [x] CI passes (typecheck & build)
- [x] Docs updated (if needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Pull Requests metric to the GitHub badge, rotating through stars → forks → PRs with matching icons and human-friendly counts.
* **Refactor**
  * Switched data sourcing to Shields.io badges for stars, forks, and PRs; fetches performed in parallel.
  * Adjusted caching to suit the new data source.
* **Bug Fixes / Resilience**
  * Improved fallback behavior and timeout handling (returns 408 on timeout) to ensure consistent badge loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->