### PR TITLE
Added ```.prettierignore``` to avoid unnecessary difs

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,38 @@
+# Dependencies
+node_modules
+
+# Build outputs
+dist
+build
+.out
+
+# Next.js
+.next
+.nuxt
+.vercel
+
+# Logs
+*.log
+
+# Environment files
+.env*.local
+
+# IDE and editor files
+.vscode
+.idea
+*.swp
+*.swo
+
+# OS generated files
+.DS_Store
+Thumbs.db
+
+# Temporary files
+tmp
+temp
+
+# Coverage reports
+coverage
+
+# Lock files (if using other formatters)
+pnpm-lock.yaml


### PR DESCRIPTION
This PR adds a .prettierignore file to prevent Prettier from formatting files or directories that don’t need automated styling. This helps reduce unnecessary diffs in commits and code reviews.

### Changes

- Added a new .prettierignore file at the project root.
- Configured it to exclude files and folders that should not be auto-formatted (e.g. build artifacts, dependency folders, static assets, and generated files).
- No code logic or functionality changes were made.

### Impact

- Cleaner diffs in pull requests.
- Improved consistency in formatting by focusing Prettier on relevant source files only.
- Easier code review and better developer experience.

### Checklist
- [x] Title is clear and descriptive
- [x] Related issue linked (if any) #289 
- [x] Tests or manual verification steps included
- [ ] CI passes (typecheck & build)
- [ ] Docs updated (if needed)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured the code formatter to ignore dependencies, build outputs, framework/hosting artifacts, logs, environment files, IDE/editor settings, OS-generated files, temporary folders, coverage reports, and lockfiles. This streamlines formatting, reduces diff noise, and speeds up pre-commit hooks and CI runs. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->