### PR TITLE
fix: invalid link on homepage

### DIFF
--- a/src/components/landing/components.tsx
+++ b/src/components/landing/components.tsx
@@ -49,7 +49,7 @@ export function ComponentsSection() {
       id: "banner",
       label: "Banner Notifications",
       icon: BsBell,
-      href: "/components/banner",
+      href: "/docs/components/banner",
     },
     {
       id: "usage",


### PR DESCRIPTION
### Summary
Invalid banner link on home page


