### PR TITLE
Fix: Prevent Heading Descender Clipping in Pricing Table Components 5 and 7

### DIFF
--- a/src/registry/billingsdk/pricing-table-five.tsx
+++ b/src/registry/billingsdk/pricing-table-five.tsx
@@ -233,8 +233,8 @@ export function PricingTableFive({
 
       <div className="container max-w-7xl mx-auto relative">
         {/* Header */}
-        <div className="text-center mb-12">
-          <h2 className={cn(titleVariants({ size, theme }))}>{title}</h2>
+        <div className="text-center mb-12 pb-1">
+          <h2 className={cn(titleVariants({ size, theme }), "leading-[1.12]")}>{title}</h2>
           <p className={cn(descriptionVariants({ size }))}>{description}</p>
 
           {/* Billing Toggle */}

--- a/src/registry/billingsdk/pricing-table-seven.tsx
+++ b/src/registry/billingsdk/pricing-table-seven.tsx
@@ -231,8 +231,8 @@ export function PricingTableSeven({
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         {/* Hero Section */}
-        <div className="text-center">
-          <h1 className={cn(titleVariants({ size, theme }))}>
+        <div className="text-center pb-1">
+          <h1 className={cn(titleVariants({ size, theme }), "leading-[1.12]")}>
             {title}
           </h1>
           <p className={cn(descriptionVariants({ size, theme }), "mt-6")}>


### PR DESCRIPTION
### Summary
This PR addresses an issue where text containing descenders (such as "g", "y", etc.) in the Pricing Table Five and Pricing Table Seven components was being clipped. This fix ensures that descenders render fully without being cut off by adding a small bottom padding to the container div wrapping the heading.

### Changes
- Added bottom padding to the container div wrapping the headings in both Pricing Table Five and Pricing Table Seven components.
- This ensures that descenders (e.g., "g", "y") in the headings are fully visible and not clipped.

### Screenshots/Recordings (if UI)
Before-
<img width="1555" height="542" alt="image" src="https://github.com/user-attachments/assets/2f1b3870-342c-458f-a62b-91b23bcf287b" />
<img width="1493" height="468" alt="image" src="https://github.com/user-attachments/assets/f1cfb8ef-3e46-42cd-b98d-d61c4e753c49" />

After-
<img width="1447" height="507" alt="image" src="https://github.com/user-attachments/assets/9527115f-4a5b-48c4-83a8-1825e5060538" />
<img width="1429" height="458" alt="image" src="https://github.com/user-attachments/assets/ddfa0fbb-2e3f-49e9-ad1c-2f366e152cf4" />


### How to Test
Steps to validate locally:
1. npm ci
2. npm run typecheck
3. npm run build
4. Run the app and navigate to the Pricing Table Five and Pricing Table Seven components.
5. Inspect the headings that contain letters with descenders (e.g., "g", "y").
6. Ensure that the bottom part of the letters is no longer clipped and they render fully.

### Checklist
- [x] Title is clear and descriptive
- [x] Related issue linked (Closes #305)
- [x] Tests or manual verification steps included
- [x] CI passes (typecheck & build)
- [x] Docs updated (if needed)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined typography line-height and spacing in pricing table layouts for improved visual hierarchy and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->