### PR TITLE
fix(playground): resolve blank screen when clicking ```code``` & ```preview``` buttons

### DIFF
--- a/src/components/playground/playground-header.tsx
+++ b/src/components/playground/playground-header.tsx
@@ -69,7 +69,9 @@ export function PlaygroundHeader() {
 
       // Default selection (pricing first item)
       if (!state.selectedComponent) {
-        const pricingComponent = list.find((comp) => comp.category === "pricing");
+        const pricingComponent = list.find(
+          (comp) => comp.category === "pricing",
+        );
         if (pricingComponent) {
           await handleComponentChange(pricingComponent.id);
         }
@@ -92,8 +94,8 @@ export function PlaygroundHeader() {
     selectedCategory === "all"
       ? componentList
       : componentList.filter(
-        (comp: ComponentListItem) => comp.category === selectedCategory,
-      );
+          (comp: ComponentListItem) => comp.category === selectedCategory,
+        );
 
   const handleImportComponent = () => {
     // Create a file input element
@@ -166,13 +168,13 @@ export function PlaygroundHeader() {
                   : isLoadingComponent
                     ? "Loading component..."
                     : state.selectedComponent?.name ||
-                    (isLoading ? "Loading..." : "Select a component")}
+                      (isLoading ? "Loading..." : "Select a component")}
               </SelectValue>
             </SelectTrigger>
             <SelectContent className="max-h-96 w-64 min-w-64 overflow-y-auto">
               {categories.map((category) => (
                 <div key={category.id} className="flex flex-col gap-2 py-2">
-                  <div className="text-muted-foreground px-3 rounded-md w-fit text-xs font-semibold">
+                  <div className="text-muted-foreground w-fit rounded-md px-3 text-xs font-semibold">
                     {category.label}
                   </div>
                   {filteredComponents

--- a/src/components/playground/playground.tsx
+++ b/src/components/playground/playground.tsx
@@ -112,31 +112,49 @@ function PlaygroundContent() {
 
       {/* Panel Controls */}
       <div className="border-border bg-muted/50 flex items-center justify-between border-b px-4 py-2">
-        <div className="flex items-center gap-2 justify-center w-full">
-          <Button size="sm" variant="ghost" onClick={() => togglePanel('code')}
+        <div className="flex w-full items-center justify-center gap-2">
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => togglePanel("code")}
             style={{ boxShadow: "inset 0 2px 4px rgba(202, 199, 199, 0.41)" }}
             className={cn(
               "text-muted-foreground hover:!bg-accent",
-              showCodePanel && "text-foreground bg-accent-foreground dark:bg-accent/50",
+              showCodePanel &&
+                "text-foreground bg-accent-foreground dark:bg-accent/50",
             )}
           >
             <PanelLeft className="mr-1 h-4 w-4" />
             Code
           </Button>
-          <Button size="sm" variant="ghost" onClick={() => togglePanel('both')}
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => togglePanel("both")}
             style={{ boxShadow: "inset 0 2px 4px rgba(202, 199, 199, 0.41)" }}
             className={cn(
               "text-muted-foreground hover:!bg-accent",
-              showCodePanel && showPreviewPanel && "text-foreground bg-accent-foreground dark:bg-accent/50",
+              showCodePanel &&
+                showPreviewPanel &&
+                "text-foreground bg-accent-foreground dark:bg-accent/50",
             )}
           >
-            <Link className={cn("rotate-45", showCodePanel && showPreviewPanel && "text-foreground")} />
+            <Link
+              className={cn(
+                "rotate-45",
+                showCodePanel && showPreviewPanel && "text-foreground",
+              )}
+            />
           </Button>
-          <Button size="sm" variant="ghost" onClick={() => togglePanel('preview')}
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => togglePanel("preview")}
             style={{ boxShadow: "inset 0 2px 4px rgba(202, 199, 199, 0.41)" }}
             className={cn(
               "text-muted-foreground hover:!bg-accent",
-              showPreviewPanel && "text-foreground bg-accent-foreground dark:bg-accent/50"
+              showPreviewPanel &&
+                "text-foreground bg-accent-foreground dark:bg-accent/50",
             )}
           >
             <PanelRight className="mr-1 h-4 w-4" />


### PR DESCRIPTION
### Summary

Fixes a blank screen issue on the `/playground` page when using the `Code` & `Preview` buttons and improves visual clarity in the `PlaygroundHeader` & also adds a default component on page load.

### Changes

- Fixed rendering issue causing a blank screen when clicking both `Code` & `Preview` button
- Added clear UI differentiation between category label and component name in `PlaygroundHeader`
- Added a Link button to select both `Code` & `Preview`
- Added a default component on page load to enhance the UX

### Screenshots/Recordings (if UI)
#### Before

https://github.com/user-attachments/assets/4bfd18d3-ce50-43dc-b1e6-f47b263f78ba

#### After

https://github.com/user-attachments/assets/b719027a-a141-41e0-8077-b85c47dc16db



### How to Test

Steps to validate locally:

1. npm ci
2. npm run typecheck
3. npm run build

### Checklist

- [x] Title is clear and descriptive
- [ ] Related issue linked (if any)
- [x] Tests or manual verification steps included
- [x] CI passes (typecheck & build)
- [ ] Docs updated (if needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Components are dynamically loaded and organized by category on page load.
  * A default component is automatically selected when the playground opens.
  * Added a new button to toggle both code and preview panels simultaneously.

* **UI/Style**
  * Panel controls redesigned with centered layout, improved spacing, and clearer visibility icons.
  * Category labels and item layout updated for lighter, rounded labels and improved item spacing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->