### PR TITLE
Github Button Responsiveness Fixed.

### DIFF
--- a/src/components/landing/footer.tsx
+++ b/src/components/landing/footer.tsx
@@ -10,7 +10,7 @@ import Image from "next/image";
 
 export function Footer() {
   return (
-        <footer className="relative min-h-[18rem] w-full overflow-hidden rounded-2xl border sm:h-[20rem]">
+    <footer className="relative min-h-[18rem] w-full overflow-hidden rounded-2xl border sm:h-[20rem]">
       <Image
         src="/landing/FractalMaze.jpg"
         alt="Moon background"
@@ -23,12 +23,12 @@ export function Footer() {
         <LogoMark className="size-32" />
       </div>
 
-            <div className="relative z-10 flex h-full flex-col items-start justify-between px-4 pt-2 pb-2 sm:justify-center sm:pb-4 md:px-8">
+      <div className="relative z-10 flex h-full flex-col items-start justify-between px-4 pt-2 pb-2 sm:justify-center sm:pb-4 md:px-8">
         <div className="relative flex flex-col items-start justify-start">
           <p className="mt-2 max-w-lg text-left text-lg font-semibold tracking-tight text-white sm:mt-3 sm:text-xl md:text-3xl">
             Ready to use billing components and blocks for your next project?
           </p>
-                    <p className="max-w-xl pt-2 text-left text-xs text-neutral-200 sm:pt-3 sm:text-sm">
+          <p className="max-w-xl pt-2 text-left text-xs text-neutral-200 sm:pt-3 sm:text-sm">
             Free Billing components and blocks built with React, Typescript,
             Tailwind CSS, and Motion. Perfect companion for shadcn/ui.
           </p>


### PR DESCRIPTION
The Github Button which was below Get Started Button was not Responsive for Small Size (320ox) Mobile screens.

NOW - 

<img width="330" height="485" alt="Screenshot 2026-02-08 at 1 57 09 AM" src="https://github.com/user-attachments/assets/a1ef3bf7-de98-439a-ae32-155abd2b2658" />

<br></br>

BEFORE - 

<img width="330" height="485" alt="Screenshot 2026-02-08 at 1 57 39 AM" src="https://github.com/user-attachments/assets/2f3495fd-0cf0-4b55-b624-ee0310751d87" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined footer styling and responsive layout behavior across all screen sizes.
  * Improved spacing and padding throughout footer elements.
  * Adjusted typography sizing and margins for better visual hierarchy.
  * Optimized button dimensions for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->