### PR TITLE
fix: hover effect on enterprise contact sales button

### DIFF
--- a/src/registry/billingsdk/pricing-table-five.tsx
+++ b/src/registry/billingsdk/pricing-table-five.tsx
@@ -457,7 +457,7 @@ export function PricingTableFive({
                 <Button
                   onClick={() => onPlanSelect?.(contactUsPlan.id)}
                   variant="outline"
-                  className="hover:bg-primary hover:text-primary-foreground w-full transition-colors"
+                  className="hover:bg-primary w-full transition-colors"
                 >
                   {contactUsPlan.buttonText}
                 </Button>


### PR DESCRIPTION
### Summary

In Pricing Table 5, on hover on the "Contact Sales" button of the enterprise section the text is not visible

### Changes

- Removed `hover:text-primary-foreground` classname from contact sales button

### Screenshots/Recordings (if UI)

Before:
https://github.com/user-attachments/assets/90709ba0-846d-4aa8-92d7-c63bd3bad849

After:
https://github.com/user-attachments/assets/2c445ad9-f4c6-4aff-a283-0c98e8542adb


### How to Test

Visit Pricing Table 5 page and hover on contact sales button

Steps to validate locally:

1. npm ci
2. npm run typecheck
3. npm run build

### Checklist

- [x] Title is clear and descriptive
- [ ] Related issue linked (if any)
- [x] Tests or manual verification steps included
- [x] CI passes (typecheck & build)
- [ ] Docs updated (if needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated contact plan button hover effect by removing the text color change during hover interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->