### PR TITLE
bug:Fixed the missing Copy button in Installation Section

### DIFF
--- a/src/components/landing/quick-integrations.tsx
+++ b/src/components/landing/quick-integrations.tsx
@@ -134,7 +134,9 @@ const CodeExample = ({
               className="max-w-full bg-black/20 backdrop-blur-lg md:max-w-md"
               code={example.commands.npm}
               language={example.language}
-            ></CodeBlock>
+            >
+              <CodeBlockCopyButton />
+            </CodeBlock>
           </CodeBlockTab>
 
           <CodeBlockTab value="pnpm" className="w-full p-2">
@@ -142,7 +144,9 @@ const CodeExample = ({
               className="max-w-full bg-black/20 backdrop-blur-lg md:max-w-md"
               code={example.commands.pnpm}
               language={example.language}
-            ></CodeBlock>
+            >
+              <CodeBlockCopyButton />
+            </CodeBlock>
           </CodeBlockTab>
 
           <CodeBlockTab value="bun" className="w-full p-2">
@@ -150,7 +154,9 @@ const CodeExample = ({
               className="max-w-full bg-black/20 backdrop-blur-lg md:max-w-md"
               code={example.commands.bun}
               language={example.language}
-            ></CodeBlock>
+            >
+              <CodeBlockCopyButton />
+            </CodeBlock>
           </CodeBlockTab>
         </CodeBlockTabs>
       </div>


### PR DESCRIPTION
### Summary

This PR adds the missing copy button inside the installation block. https://github.com/dodopayments/billingsdk/issues/363

### Changes

- Changed the ```src/components/landing/quick-integrations.tsx``` file to add copy button here 

### Screenshots/Recordings (if UI)
- Before
<img width="566" height="291" alt="Screenshot 2026-02-18 at 5 32 19 AM" src="https://github.com/user-attachments/assets/80f5d38f-cbe7-418e-bff6-80cc68ef151f" />

- After 
<img width="524" height="234" alt="Screenshot 2026-02-18 at 5 40 28 AM" src="https://github.com/user-attachments/assets/e1edb8f6-9109-4a33-8027-ea44b7dc5f17" />


### How to Test

Steps to validate locally:

1. npm ci
2. npm run typecheck
3. npm run build

### Checklist

- [x] Title is clear and descriptive
- [x] Related issue linked (if any)
- [ ] Tests or manual verification steps included
- [ ] CI passes (typecheck & build)
- [ ] Docs updated (if needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added copy buttons to code blocks on the landing page integration examples, enabling users to quickly copy code snippets for npm, pnpm, and bun package managers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->